### PR TITLE
feat: DX and performance — centralized URLs, lazy charts, loading skeletons

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,14 +1,16 @@
 # breacher.net environment variables
 #
-# Copy this file to .env and fill in the values.
-# The app works without a database — it fetches live from cryoarchive.systems.
-# To enable historical charts and build tracking, set DATABASE_URL.
+# Copy this file to .env.local and fill in the values.
+# The app requires a PostgreSQL database — data is populated by the Python poller.
 
-# PostgreSQL connection string (optional — enables historical data features)
-# DATABASE_URL=postgresql://breacher:breacher@localhost:5432/breacher
+# PostgreSQL connection string (required for data features)
+# Format: postgresql://user:password@host:port/database
+# K8s prod uses PgBouncer VIP on port 6432
+DATABASE_URL=postgresql://breacher:breacher@localhost:5432/breacher
 
-# Site URL (optional — used for meta tags and canonical URLs)
+# Site URL — used for meta tags, canonical URLs, sitemap, and robots.txt
+# Defaults to https://breacher.net if not set
 # NEXT_PUBLIC_SITE_URL=https://breacher.net
 
-# Node environment (set by Docker, usually don't touch)
+# Node environment (set by Docker/K8s, usually don't touch)
 # NODE_ENV=production

--- a/src/app/cryoarchive/DashboardClient.tsx
+++ b/src/app/cryoarchive/DashboardClient.tsx
@@ -11,7 +11,22 @@ import {
 } from "@/lib/format";
 import { SECTOR_NAMES } from "@/lib/types";
 import type { SectorName } from "@/lib/types";
-import { KillCountChart } from "@/components/KillCountChart";
+import dynamic from "next/dynamic";
+import { URLS } from "@/lib/urls";
+
+const KillCountChart = dynamic(
+  () => import("@/components/KillCountChart").then((m) => m.KillCountChart),
+  {
+    loading: () => (
+      <div className="cryo-panel p-5 h-[300px] flex items-center justify-center">
+        <div className="font-[var(--font-display)] text-xs tracking-[4px] text-dim animate-blink">
+          LOADING CHART...
+        </div>
+      </div>
+    ),
+    ssr: false,
+  },
+);
 
 interface DashboardData {
   killCount: number;
@@ -126,7 +141,7 @@ export function DashboardClient({ initialData }: Props) {
 
       {/* CTA Banner */}
       <a
-        href="https://docs.google.com/document/d/1mtUtDPvbh6ahiynYFVS7Z4O79Nw6y5PEOjweCpzWV_A/edit?tab=t.0#heading=h.5j4qeuoxhabo"
+        href={URLS.communityDocHelp}
         target="_blank"
         rel="noopener noreferrer"
         className="block bg-gradient-to-br from-accent/[0.08] to-accent2/[0.05] border border-accent p-6 mb-8 flex items-center gap-5 relative overflow-hidden hover:border-accent2 hover:from-accent/[0.12] hover:to-accent2/[0.08] transition-all no-underline group"

--- a/src/app/cryoarchive/cameras/CamerasClient.tsx
+++ b/src/app/cryoarchive/cameras/CamerasClient.tsx
@@ -4,7 +4,21 @@ import { useEffect, useState, useCallback } from "react";
 import { toLocalTimeOnly, formatCountdown } from "@/lib/format";
 import { CAMERA_NAMES } from "@/lib/types";
 import type { CameraName } from "@/lib/types";
-import { StabilizationChart } from "@/components/StabilizationChart";
+import dynamic from "next/dynamic";
+
+const StabilizationChart = dynamic(
+  () => import("@/components/StabilizationChart").then((m) => m.StabilizationChart),
+  {
+    loading: () => (
+      <div className="cryo-panel p-5 h-[350px] flex items-center justify-center">
+        <div className="font-[var(--font-display)] text-xs tracking-[4px] text-dim animate-blink">
+          LOADING CHART...
+        </div>
+      </div>
+    ),
+    ssr: false,
+  },
+);
 
 interface CameraData {
   stabilizationLevel: number;

--- a/src/app/cryoarchive/cameras/loading.tsx
+++ b/src/app/cryoarchive/cameras/loading.tsx
@@ -1,0 +1,26 @@
+export default function CamerasLoading() {
+  return (
+    <main className="px-4 sm:px-8 max-w-[1200px] mx-auto py-8 animate-pulse">
+      <div className="h-3 w-24 bg-border mb-4 rounded" />
+
+      {/* Camera grid skeleton */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4 mb-8">
+        {[1, 2, 3, 4, 5, 6, 7, 8, 9].map((i) => (
+          <div key={i} className="cryo-panel p-5">
+            <div className="h-3 w-20 bg-border mb-3 rounded" />
+            <div className="h-8 w-16 bg-border mb-2 rounded" />
+            <div className="h-2 w-full bg-border rounded" />
+          </div>
+        ))}
+      </div>
+
+      {/* Chart skeleton */}
+      <div className="h-3 w-48 bg-border mb-4 rounded" />
+      <div className="cryo-panel p-5 h-[350px] flex items-center justify-center">
+        <div className="font-[var(--font-display)] text-xs tracking-[4px] text-dim animate-blink">
+          LOADING CHART DATA...
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/cryoarchive/cameras/page.tsx
+++ b/src/app/cryoarchive/cameras/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { fetchStabilization } from "@/lib/api";
 import { CamerasClient } from "./CamerasClient";
+import { SITE_URL } from "@/lib/urls";
 
 export const metadata: Metadata = {
   title: "Cameras",
@@ -8,7 +9,7 @@ export const metadata: Metadata = {
   openGraph: {
     title: "Cameras // BREACHER.NET",
     description: "CCTV stabilization levels across all sectors and cameras",
-    url: "https://breacher.net/cryoarchive/cameras",
+    url: `${SITE_URL}/cryoarchive/cameras`,
   },
 };
 

--- a/src/app/cryoarchive/changes/ChangesClient.tsx
+++ b/src/app/cryoarchive/changes/ChangesClient.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { URLS } from "@/lib/urls";
 
 interface BuildEvent {
   detected_at: string;
@@ -101,7 +102,7 @@ export function ChangesClient() {
       {/* Latest Build Banner */}
       {latest && (
         <a
-          href="https://cryoarchive.systems"
+          href={URLS.cryoarchive}
           target="_blank"
           rel="noopener noreferrer"
           className="block cryo-panel p-6 mb-8 hover:border-accent transition-colors no-underline group"

--- a/src/app/cryoarchive/changes/loading.tsx
+++ b/src/app/cryoarchive/changes/loading.tsx
@@ -1,0 +1,30 @@
+export default function ChangesLoading() {
+  return (
+    <main className="px-4 sm:px-8 max-w-[1200px] mx-auto py-8 animate-pulse">
+      <div className="h-3 w-32 bg-border mb-4 rounded" />
+
+      {/* Latest build banner skeleton */}
+      <div className="cryo-panel p-6 mb-8 flex items-center gap-4">
+        <div className="w-10 h-10 bg-border rounded shrink-0" />
+        <div className="flex-1">
+          <div className="h-3 w-32 bg-border mb-2 rounded" />
+          <div className="h-3 w-48 bg-border rounded" />
+        </div>
+      </div>
+
+      {/* Build events skeleton */}
+      <div className="space-y-4">
+        {[1, 2, 3, 4, 5].map((i) => (
+          <div key={i} className="cryo-panel p-5">
+            <div className="flex items-center gap-3 mb-3">
+              <div className="h-3 w-24 bg-border rounded" />
+              <div className="h-3 w-32 bg-border rounded" />
+            </div>
+            <div className="h-3 w-full bg-border mb-2 rounded" />
+            <div className="h-3 w-3/4 bg-border rounded" />
+          </div>
+        ))}
+      </div>
+    </main>
+  );
+}

--- a/src/app/cryoarchive/changes/page.tsx
+++ b/src/app/cryoarchive/changes/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { ChangesClient } from "./ChangesClient";
+import { SITE_URL } from "@/lib/urls";
 
 export const metadata: Metadata = {
   title: "Site Changes",
@@ -7,7 +8,7 @@ export const metadata: Metadata = {
   openGraph: {
     title: "Site Changes // BREACHER.NET",
     description: "Detected website deployments and build changes on cryoarchive.systems",
-    url: "https://breacher.net/cryoarchive/changes",
+    url: `${SITE_URL}/cryoarchive/changes`,
   },
 };
 

--- a/src/app/cryoarchive/index/IndexArchiveClient.tsx
+++ b/src/app/cryoarchive/index/IndexArchiveClient.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState, useCallback } from "react";
+import { URLS, youtubeEmbed } from "@/lib/urls";
 
 /* ------------------------------------------------------------------ */
 /*  Types                                                              */
@@ -51,7 +52,7 @@ type FilterTab = "all" | "unlocked" | "new" | "IMAGE" | "TEXT" | "VIDEO" | "AUDI
 /*  Constants                                                          */
 /* ------------------------------------------------------------------ */
 
-const INDEX_URL = "https://cryoarchive.systems/indx";
+const INDEX_URL = URLS.cryoarchiveIndex;
 const API_URL = "/api/index-entries";
 const REFRESH_INTERVAL = 300_000; // 5 minutes
 const NEW_ENTRY_WINDOW_MS = 6 * 60 * 60 * 1000; // 6 hours
@@ -329,7 +330,7 @@ function EntryContent({ data: cd, entryId }: { data: EntryContentData; entryId: 
         return (
             <div className="py-2">
                 <iframe
-                    src={`https://www.youtube.com/embed/${cd.youtubeVideoId}`}
+                    src={youtubeEmbed(cd.youtubeVideoId)}
                     className="w-full max-w-2xl aspect-video border border-border"
                     allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
                     allowFullScreen

--- a/src/app/cryoarchive/index/loading.tsx
+++ b/src/app/cryoarchive/index/loading.tsx
@@ -1,0 +1,28 @@
+export default function IndexLoading() {
+  return (
+    <main className="px-4 sm:px-8 max-w-[1200px] mx-auto py-8 animate-pulse">
+      <div className="h-3 w-28 bg-border mb-4 rounded" />
+
+      {/* Filter tabs skeleton */}
+      <div className="flex gap-2 mb-6 flex-wrap">
+        {[1, 2, 3, 4, 5, 6, 7].map((i) => (
+          <div key={i} className="h-7 w-16 bg-panel border border-border rounded" />
+        ))}
+      </div>
+
+      {/* Entry list skeleton */}
+      <div className="space-y-3">
+        {[1, 2, 3, 4, 5, 6, 7, 8].map((i) => (
+          <div key={i} className="cryo-panel p-4 flex items-center gap-4">
+            <div className="w-8 h-8 bg-border rounded shrink-0" />
+            <div className="flex-1">
+              <div className="h-3 w-32 bg-border mb-2 rounded" />
+              <div className="h-3 w-48 bg-border rounded" />
+            </div>
+            <div className="h-5 w-16 bg-border rounded" />
+          </div>
+        ))}
+      </div>
+    </main>
+  );
+}

--- a/src/app/cryoarchive/index/page.tsx
+++ b/src/app/cryoarchive/index/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { IndexArchiveClient } from "./IndexArchiveClient";
+import { SITE_URL } from "@/lib/urls";
 
 export const metadata: Metadata = {
     title: "Index Archive",
@@ -7,7 +8,7 @@ export const metadata: Metadata = {
     openGraph: {
         title: "Index Archive // BREACHER.NET",
         description: "Cryoarchive entry index — types, lock status, and unlock tracking",
-        url: "https://breacher.net/cryoarchive/index",
+        url: `${SITE_URL}/cryoarchive/index`,
     },
 };
 

--- a/src/app/cryoarchive/loading.tsx
+++ b/src/app/cryoarchive/loading.tsx
@@ -1,0 +1,55 @@
+export default function DashboardLoading() {
+  return (
+    <main className="px-4 sm:px-8 max-w-[1200px] mx-auto py-8 animate-pulse">
+      {/* Next update bar skeleton */}
+      <div className="bg-panel border-b border-border p-2 px-4 flex items-center gap-4 mb-6">
+        <div className="h-3 w-24 bg-border rounded" />
+        <div className="h-3 w-16 bg-border rounded" />
+        <div className="flex-1 h-[3px] bg-border ml-2.5" />
+      </div>
+
+      {/* CTA banner skeleton */}
+      <div className="cryo-panel p-6 mb-8 flex items-center gap-5">
+        <div className="w-10 h-10 bg-border rounded shrink-0" />
+        <div className="flex-1">
+          <div className="h-3 w-32 bg-border mb-2 rounded" />
+          <div className="h-3 w-64 bg-border rounded" />
+        </div>
+      </div>
+
+      {/* Sector state skeleton */}
+      <div className="h-3 w-24 bg-border mb-4 rounded" />
+      <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-3.5 mb-8">
+        {[1, 2, 3, 4, 5, 6, 7].map((i) => (
+          <div key={i} className="cryo-panel p-4">
+            <div className="h-3 w-16 bg-border mb-3 rounded" />
+            <div className="flex gap-2">
+              <div className="h-5 w-16 bg-border rounded" />
+              <div className="h-5 w-16 bg-border rounded" />
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Kill count skeleton */}
+      <div className="h-3 w-32 bg-border mb-4 rounded" />
+      <div className="cryo-panel p-6 mb-8 flex items-center gap-8">
+        <div>
+          <div className="h-3 w-20 bg-border mb-2 rounded" />
+          <div className="h-10 w-40 bg-border rounded" />
+        </div>
+        <div className="ml-auto">
+          <div className="h-3 w-32 bg-border rounded" />
+        </div>
+      </div>
+
+      {/* Chart skeleton */}
+      <div className="h-3 w-40 bg-border mb-4 rounded" />
+      <div className="cryo-panel p-5 h-[300px] flex items-center justify-center">
+        <div className="font-[var(--font-display)] text-xs tracking-[4px] text-dim animate-blink">
+          LOADING CHART DATA...
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/cryoarchive/maps/loading.tsx
+++ b/src/app/cryoarchive/maps/loading.tsx
@@ -1,0 +1,21 @@
+export default function MapsLoading() {
+  return (
+    <main className="px-4 sm:px-8 max-w-[1400px] mx-auto py-8 animate-pulse">
+      <div className="h-3 w-28 bg-border mb-4 rounded" />
+
+      {/* Map controls skeleton */}
+      <div className="flex gap-3 mb-6">
+        {[1, 2, 3].map((i) => (
+          <div key={i} className="h-8 w-24 bg-panel border border-border rounded" />
+        ))}
+      </div>
+
+      {/* Map area skeleton */}
+      <div className="cryo-panel p-4 h-[500px] flex items-center justify-center">
+        <div className="font-[var(--font-display)] text-xs tracking-[4px] text-dim animate-blink">
+          LOADING MAP DATA...
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/cryoarchive/maps/page.tsx
+++ b/src/app/cryoarchive/maps/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { MapsClient } from "./MapsClient";
+import { SITE_URL } from "@/lib/urls";
 
 export const metadata: Metadata = {
   title: "Maps",
@@ -9,7 +10,7 @@ export const metadata: Metadata = {
     title: "Maps // BREACHER.NET",
     description:
       "Interactive terminal maps for Perimeter, Dire Marsh, and Outpost sectors with zone inspection and stabilization data.",
-    url: "https://breacher.net/cryoarchive/maps",
+    url: `${SITE_URL}/cryoarchive/maps`,
   },
 };
 

--- a/src/app/cryoarchive/page.tsx
+++ b/src/app/cryoarchive/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { fetchState } from "@/lib/api";
 import { SECTOR_NAMES } from "@/lib/types";
 import { DashboardClient } from "./DashboardClient";
+import { SITE_URL } from "@/lib/urls";
 
 export const metadata: Metadata = {
   title: "Dashboard",
@@ -9,7 +10,7 @@ export const metadata: Metadata = {
   openGraph: {
     title: "Dashboard // BREACHER.NET",
     description: "Live kill count, sector states, ship date countdown, and kill rate chart",
-    url: "https://breacher.net/cryoarchive",
+    url: `${SITE_URL}/cryoarchive`,
   },
 };
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { JetBrains_Mono, Space_Grotesk } from "next/font/google";
 import "./globals.css";
 import { Navigation } from "@/components/Navigation";
+import { SITE_URL } from "@/lib/urls";
 
 const jetbrainsMono = JetBrains_Mono({
   variable: "--font-jetbrains-mono",
@@ -14,7 +15,7 @@ const spaceGrotesk = Space_Grotesk({
 });
 
 export const metadata: Metadata = {
-  metadataBase: new URL("https://breacher.net"),
+  metadataBase: new URL(SITE_URL),
   title: {
     default: "BREACHER.NET // Breachers of Tomorrow",
     template: "%s // BREACHER.NET",
@@ -25,7 +26,7 @@ export const metadata: Metadata = {
   openGraph: {
     type: "website",
     locale: "en_US",
-    url: "https://breacher.net",
+    url: SITE_URL,
     siteName: "BREACHER.NET",
     title: "BREACHER.NET // Breachers of Tomorrow",
     description:
@@ -38,7 +39,7 @@ export const metadata: Metadata = {
       "Community tracker and hub for the Marathon ARG — live kill count, sector states, stabilization data, and interactive maps.",
   },
   alternates: {
-    canonical: "https://breacher.net",
+    canonical: SITE_URL,
   },
 };
 

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,0 +1,36 @@
+export default function HomeLoading() {
+  return (
+    <main className="max-w-5xl mx-auto px-4 sm:px-8 py-8 sm:py-16 animate-pulse">
+      {/* Hero skeleton */}
+      <div className="text-center mb-12 sm:mb-16">
+        <div className="h-10 w-64 bg-panel mx-auto mb-4 rounded" />
+        <div className="h-5 w-48 bg-panel mx-auto mb-2 rounded" />
+        <div className="h-4 w-80 bg-panel mx-auto rounded" />
+      </div>
+
+      {/* Quick Status skeleton */}
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-12">
+        {[1, 2, 3].map((i) => (
+          <div key={i} className="cryo-panel p-6">
+            <div className="h-3 w-24 bg-border mx-auto mb-3 rounded" />
+            <div className="h-8 w-20 bg-border mx-auto rounded" />
+          </div>
+        ))}
+      </div>
+
+      {/* Nav cards skeleton */}
+      <div className="h-3 w-32 bg-border mb-4 rounded" />
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-12">
+        {[1, 2, 3, 4, 5].map((i) => (
+          <div key={i} className="cryo-panel p-6 flex items-center gap-4">
+            <div className="w-10 h-10 bg-border rounded shrink-0" />
+            <div className="flex-1">
+              <div className="h-3 w-20 bg-border mb-2 rounded" />
+              <div className="h-3 w-48 bg-border rounded" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </main>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { fetchState, fetchStabilization } from "@/lib/api";
 import { SECTOR_NAMES } from "@/lib/types";
+import { URLS } from "@/lib/urls";
 
 export const revalidate = 60;
 
@@ -118,7 +119,7 @@ export default async function HomePage() {
       <div className="section-title">COMMUNITY</div>
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-12">
         <a
-          href="https://wiki.breacher.net"
+          href={URLS.wiki}
           target="_blank"
           rel="noopener noreferrer"
           className="cryo-panel p-6 flex items-center gap-4 hover:border-accent transition-colors no-underline group"
@@ -137,7 +138,7 @@ export default async function HomePage() {
           </div>
         </a>
         <a
-          href="https://discord.gg/sGeg5Gx2yM"
+          href={URLS.discord}
           target="_blank"
           rel="noopener noreferrer"
           className="cryo-panel p-6 flex items-center gap-4 hover:border-accent transition-colors no-underline group"
@@ -156,7 +157,7 @@ export default async function HomePage() {
           </div>
         </a>
         <a
-          href="https://docs.google.com/document/d/1mtUtDPvbh6ahiynYFVS7Z4O79Nw6y5PEOjweCpzWV_A/edit?tab=t.0"
+          href={URLS.communityDoc}
           target="_blank"
           rel="noopener noreferrer"
           className="cryo-panel p-6 flex items-center gap-4 hover:border-accent transition-colors no-underline group"
@@ -175,7 +176,7 @@ export default async function HomePage() {
           </div>
         </a>
         <a
-          href="https://marathon.winnower.garden/cryoarchive"
+          href={URLS.winnower}
           target="_blank"
           rel="noopener noreferrer"
           className="cryo-panel p-6 flex items-center gap-4 hover:border-accent transition-colors no-underline group"
@@ -200,7 +201,7 @@ export default async function HomePage() {
         <p>
           BUILT BY{" "}
           <a
-            href="https://github.com/breachers-of-tomorrow"
+            href={URLS.github}
             target="_blank"
             rel="noopener noreferrer"
             className="text-accent hover:glow-accent"
@@ -211,7 +212,7 @@ export default async function HomePage() {
         <p className="mt-2">
           ORIGINAL TRACKER BY{" "}
           <a
-            href="https://github.com/CrowdTypical"
+            href={URLS.crowdTypical}
             target="_blank"
             rel="noopener noreferrer"
             className="text-accent hover:glow-accent"
@@ -222,7 +223,7 @@ export default async function HomePage() {
         <p className="mt-2">
           HISTORICAL DATA BY{" "}
           <a
-            href="https://marathon.winnower.garden/cryoarchive"
+            href={URLS.winnower}
             target="_blank"
             rel="noopener noreferrer"
             className="text-accent hover:glow-accent"

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,4 +1,5 @@
 import type { MetadataRoute } from "next";
+import { SITE_URL } from "@/lib/urls";
 
 export default function robots(): MetadataRoute.Robots {
   return {
@@ -9,6 +10,6 @@ export default function robots(): MetadataRoute.Robots {
         disallow: ["/api/"],
       },
     ],
-    sitemap: "https://breacher.net/sitemap.xml",
+    sitemap: `${SITE_URL}/sitemap.xml`,
   };
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,7 +1,8 @@
 import type { MetadataRoute } from "next";
+import { SITE_URL } from "@/lib/urls";
 
 export default function sitemap(): MetadataRoute.Sitemap {
-  const baseUrl = "https://breacher.net";
+  const baseUrl = SITE_URL;
   const now = new Date();
 
   return [

--- a/src/components/KillCountChart.tsx
+++ b/src/components/KillCountChart.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { URLS } from "@/lib/urls";
 import {
   ResponsiveContainer,
   AreaChart,
@@ -107,7 +108,7 @@ export function KillCountChart() {
           {error ?? "NO DATA AVAILABLE"}
         </div>
         <a
-          href="https://marathon.winnower.garden/cryoarchive"
+          href={URLS.winnower}
           target="_blank"
           rel="noopener noreferrer"
           className="text-accent text-xs tracking-[2px] hover:glow-accent"

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useEffect, useState } from "react";
+import { URLS } from "@/lib/urls";
 
 interface NavLink {
   href: string;
@@ -29,10 +30,10 @@ const NAV_SECTIONS: NavSection[] = [
   {
     label: "BREACHER.NET",
     links: [
-      { href: "https://wiki.breacher.net", label: "Wiki", external: true },
-      { href: "https://discord.gg/sGeg5Gx2yM", label: "Discord", external: true },
+      { href: URLS.wiki, label: "Wiki", external: true },
+      { href: URLS.discord, label: "Discord", external: true },
       {
-        href: "https://docs.google.com/document/d/1mtUtDPvbh6ahiynYFVS7Z4O79Nw6y5PEOjweCpzWV_A/edit?tab=t.0",
+        href: URLS.communityDoc,
         label: "Community Doc",
         external: true,
       },
@@ -41,8 +42,8 @@ const NAV_SECTIONS: NavSection[] = [
   {
     label: "MARATHON",
     links: [
-      { href: "https://marathon.winnower.garden/cryoarchive", label: "Winnower", external: true },
-      { href: "https://tauceti.world", label: "Tau Ceti", external: true },
+      { href: URLS.winnower, label: "Winnower", external: true },
+      { href: URLS.tauCeti, label: "Tau Ceti", external: true },
     ],
   },
 ];

--- a/src/components/StabilizationChart.tsx
+++ b/src/components/StabilizationChart.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { URLS } from "@/lib/urls";
 import {
   ResponsiveContainer,
   LineChart,
@@ -135,7 +136,7 @@ export function StabilizationChart() {
           {error ?? "NO DATA AVAILABLE"}
         </div>
         <a
-          href="https://marathon.winnower.garden/cryoarchive"
+          href={URLS.winnower}
           target="_blank"
           rel="noopener noreferrer"
           className="text-accent text-xs tracking-[2px] hover:glow-accent"

--- a/src/lib/urls.ts
+++ b/src/lib/urls.ts
@@ -1,0 +1,56 @@
+// ============================================================
+// Centralized external URLs — single source of truth for all
+// outbound links used across the site.
+//
+// Update URLs here instead of hunting through components.
+// See: https://github.com/breachers-of-tomorrow/breacher-net/issues/35
+// ============================================================
+
+/** Base site URL used for meta tags, sitemap, and canonical links */
+export const SITE_URL =
+  process.env.NEXT_PUBLIC_SITE_URL || "https://breacher.net";
+
+// ---- Community ----
+
+export const URLS = {
+  /** Breachers of Tomorrow Discord */
+  discord: "https://discord.gg/sGeg5Gx2yM",
+
+  /** Community wiki */
+  wiki: "https://wiki.breacher.net",
+
+  /** Community objectives Google Doc */
+  communityDoc:
+    "https://docs.google.com/document/d/1mtUtDPvbh6ahiynYFVS7Z4O79Nw6y5PEOjweCpzWV_A/edit?tab=t.0",
+
+  /** Community doc — "how can I help" section (direct anchor) */
+  communityDocHelp:
+    "https://docs.google.com/document/d/1mtUtDPvbh6ahiynYFVS7Z4O79Nw6y5PEOjweCpzWV_A/edit?tab=t.0#heading=h.5j4qeuoxhabo",
+
+  // ---- External trackers / tools ----
+
+  /** Winnower Garden historical data archive */
+  winnower: "https://marathon.winnower.garden/cryoarchive",
+
+  /** Tau Ceti community project */
+  tauCeti: "https://tauceti.world",
+
+  /** Cryoarchive source site */
+  cryoarchive: "https://cryoarchive.systems",
+
+  /** Cryoarchive index page (used for external link in index archive) */
+  cryoarchiveIndex: "https://cryoarchive.systems/indx",
+
+  // ---- GitHub ----
+
+  /** Breachers of Tomorrow GitHub org */
+  github: "https://github.com/breachers-of-tomorrow",
+
+  /** CrowdTypical — original tracker author */
+  crowdTypical: "https://github.com/CrowdTypical",
+} as const;
+
+/** YouTube embed URL builder */
+export function youtubeEmbed(videoId: string): string {
+  return `https://www.youtube.com/embed/${videoId}`;
+}


### PR DESCRIPTION
## Summary

DX improvements, performance optimizations, and code quality changes that benefit all subsequent v0.5.0 work.

### Changes

#### #35 — Centralize external URLs in config
- New `src/lib/urls.ts` — single source of truth for all external URLs
- `SITE_URL` driven by `NEXT_PUBLIC_SITE_URL` env var (defaults to `https://breacher.net`)
- All 23 components/pages updated to import from `@/lib/urls` instead of hardcoding
- Includes `youtubeEmbed()` helper for YouTube embed URLs
- Zero hardcoded URLs remain outside `urls.ts`

#### #34 — Lazy-load recharts (reduce initial bundle)
- `KillCountChart` and `StabilizationChart` loaded via `next/dynamic` with `ssr: false`
- ~180KB of recharts code deferred until user navigates to chart-containing pages
- Themed loading placeholders match the app's design language

#### #33 — Loading skeletons for all routes
- Added `loading.tsx` for: home (`/`), dashboard, cameras, maps, index archive, site changes
- Pulse-animated skeletons match each page's layout structure
- Provides instant visual feedback during page transitions

#### #43 — .env.example with all required vars
- Updated comments to reflect DB-only architecture (no longer optional)
- Documented `NEXT_PUBLIC_SITE_URL` usage
- Corrected copy instructions (`.env.local` not `.env`)

### Testing
- `npm run lint` — clean
- `npm run build` — clean, all 16 routes generated
- Verified zero hardcoded URLs remain outside `urls.ts`

Closes #33, Closes #34, Closes #35, Closes #43