### PR TITLE
feat: Add About and Community pages with nav integration

### DIFF
--- a/src/app/about/loading.tsx
+++ b/src/app/about/loading.tsx
@@ -1,0 +1,49 @@
+export default function AboutLoading() {
+  return (
+    <main className="max-w-4xl mx-auto px-4 sm:px-8 py-8 sm:py-16 animate-pulse">
+      {/* Hero */}
+      <div className="text-center mb-12">
+        <div className="h-10 w-72 bg-panel mx-auto mb-4 rounded" />
+        <div className="h-4 w-80 bg-panel mx-auto rounded" />
+      </div>
+
+      {/* Section */}
+      <div className="h-3 w-32 bg-border mb-4 rounded" />
+      <div className="cryo-panel p-6 sm:p-8 mb-12">
+        <div className="h-4 w-full bg-border mb-3 rounded" />
+        <div className="h-4 w-5/6 bg-border mb-3 rounded" />
+        <div className="h-4 w-4/6 bg-border rounded" />
+      </div>
+
+      {/* Steps */}
+      <div className="h-3 w-28 bg-border mb-4 rounded" />
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-12">
+        {[1, 2, 3, 4].map((i) => (
+          <div key={i} className="cryo-panel p-6">
+            <div className="flex items-start gap-4">
+              <div className="w-10 h-10 bg-border rounded shrink-0" />
+              <div className="flex-1">
+                <div className="h-3 w-28 bg-border mb-3 rounded" />
+                <div className="h-3 w-full bg-border mb-2 rounded" />
+                <div className="h-3 w-3/4 bg-border rounded" />
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Contribution paths */}
+      <div className="h-3 w-36 bg-border mb-4 rounded" />
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        {[1, 2, 3, 4, 5, 6].map((i) => (
+          <div key={i} className="cryo-panel p-5">
+            <div className="w-8 h-8 bg-border mb-3 rounded" />
+            <div className="h-3 w-24 bg-border mb-2 rounded" />
+            <div className="h-3 w-full bg-border mb-1.5 rounded" />
+            <div className="h-3 w-5/6 bg-border rounded" />
+          </div>
+        ))}
+      </div>
+    </main>
+  );
+}

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,0 +1,295 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { URLS } from "@/lib/urls";
+import { SITE_URL } from "@/lib/urls";
+
+export const metadata: Metadata = {
+  title: "About",
+  description:
+    "Breachers of Tomorrow — a 1,000+ member community tracking the Marathon ARG. Who we are, what we do, and how to join.",
+  openGraph: {
+    title: "About // BREACHER.NET",
+    description:
+      "Breachers of Tomorrow — a 1,000+ member community tracking the Marathon ARG.",
+    url: `${SITE_URL}/about`,
+  },
+};
+
+export default function AboutPage() {
+  return (
+    <main className="max-w-4xl mx-auto px-4 sm:px-8 py-8 sm:py-16">
+      {/* Hero */}
+      <div className="text-center mb-12">
+        <h1 className="font-[var(--font-display)] text-2xl sm:text-4xl font-black text-accent glow-accent tracking-[6px] mb-4">
+          BREACHERS OF TOMORROW
+        </h1>
+        <p className="text-dim text-sm sm:text-base tracking-[2px] max-w-2xl mx-auto">
+          COMMUNITY TRACKER AND HUB FOR THE MARATHON ARG
+        </p>
+      </div>
+
+      {/* What Is This */}
+      <section className="mb-12">
+        <div className="section-title">WHAT IS THIS?</div>
+        <div className="cryo-panel p-6 sm:p-8 space-y-4">
+          <p className="text-foreground text-sm sm:text-base leading-relaxed">
+            <strong className="text-accent">Breachers of Tomorrow</strong> is a
+            1,000+ member community built around the{" "}
+            <a
+              href={URLS.cryoarchive}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-accent2 hover:glow-accent2"
+            >
+              Marathon ARG
+            </a>{" "}
+            by Bungie. We collaboratively solve puzzles, track changes to
+            cryoarchive.systems, and share discoveries.
+          </p>
+          <p className="text-dim text-sm leading-relaxed">
+            Bungie launched{" "}
+            <a
+              href={URLS.cryoarchive}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-accent2 hover:glow-accent2"
+            >
+              cryoarchive.systems
+            </a>{" "}
+            featuring sectors, camera feeds, a kill counter, and terminal maps.
+            This community tracks it all in real-time through breacher.net —
+            including live data feeds, stabilization monitoring, build change
+            detection, and interactive maps.
+          </p>
+        </div>
+      </section>
+
+      {/* Get Started */}
+      <section className="mb-12">
+        <div className="section-title">GET STARTED</div>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <Step
+            number="01"
+            title="JOIN THE DISCORD"
+            description="The heart of the community. Key channels: #general, #announcements, #lfg-breach-protocol"
+            href={URLS.discord}
+            cta="JOIN DISCORD"
+          />
+          <Step
+            number="02"
+            title="CHECK THE DASHBOARD"
+            description="Live kill count, sector states, camera stabilization, site changes, and terminal maps"
+            href="/cryoarchive"
+            cta="OPEN DASHBOARD"
+            internal
+          />
+          <Step
+            number="03"
+            title="READ THE RESEARCH"
+            description="Community objectives, historical data from Winnower Garden, and Tau Ceti resources"
+            href={URLS.communityDoc}
+            cta="COMMUNITY DOC"
+          />
+          <Step
+            number="04"
+            title="CONTRIBUTE"
+            description="From ARG research to code contributions — there's a path for every skill set"
+            href="/community"
+            cta="SEE HOW"
+            internal
+          />
+        </div>
+      </section>
+
+      {/* Ways to Contribute */}
+      <section className="mb-12">
+        <div className="section-title">WAYS TO CONTRIBUTE</div>
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          <ContributionPath
+            icon="🔍"
+            title="ARG RESEARCH"
+            description="Track cryoarchive changes, document findings, share theories in Discord thinking pods"
+          />
+          <ContributionPath
+            icon="💻"
+            title="CODE & TOOLS"
+            description="Contribute to breacher.net (Next.js/React/TypeScript), pollers (Python), or build new tools"
+          />
+          <ContributionPath
+            icon="✍️"
+            title="WRITING & DOCS"
+            description="Help migrate community research to the wiki, write guides, document lore and theories"
+          />
+          <ContributionPath
+            icon="🎨"
+            title="DESIGN & BRANDING"
+            description="Visual identity, social media graphics, Discord assets, community brand development"
+          />
+          <ContributionPath
+            icon="🤝"
+            title="COMMUNITY BUILDING"
+            description="Welcome new members, organize events, moderate channels, build connections"
+          />
+          <ContributionPath
+            icon="📊"
+            title="DATA & ANALYSIS"
+            description="Track sector data, analyze kill count trends, monitor stabilization patterns"
+          />
+        </div>
+      </section>
+
+      {/* Community Structure */}
+      <section className="mb-12">
+        <div className="section-title">COMMUNITY STRUCTURE</div>
+        <div className="cryo-panel p-6 sm:p-8">
+          <p className="text-dim text-sm leading-relaxed mb-4">
+            Breachers of Tomorrow is managed by a team of ~15 volunteer{" "}
+            <strong className="text-accent">
+              Keepers of The Manifest
+            </strong>{" "}
+            — experienced community members who help guide research, moderate
+            discussions, and maintain infrastructure.
+          </p>
+          <p className="text-dim text-sm leading-relaxed">
+            Everyone is welcome to contribute at their own pace. No pressure, no
+            gatekeeping — just a shared love for solving the mysteries of the
+            Marathon ARG.
+          </p>
+        </div>
+      </section>
+
+      {/* Credits */}
+      <section className="mb-12">
+        <div className="section-title">CREDITS</div>
+        <div className="cryo-panel p-6 sm:p-8 space-y-3">
+          <CreditLine
+            label="ORIGINAL TRACKER"
+            name="CrowdTypical"
+            href={URLS.crowdTypical}
+          />
+          <CreditLine
+            label="HISTORICAL DATA"
+            name="Winnower Garden"
+            href={URLS.winnower}
+          />
+          <CreditLine
+            label="COMMUNITY"
+            name="Breachers of Tomorrow"
+            href={URLS.github}
+          />
+        </div>
+      </section>
+
+      {/* Quick Links */}
+      <div className="flex flex-wrap gap-4 justify-center">
+        <Link
+          href="/community"
+          className="font-[var(--font-display)] text-xs tracking-[3px] uppercase px-6 py-3 bg-accent/10 border border-accent text-accent hover:bg-accent/20 transition-colors no-underline"
+        >
+          COMMUNITY RESOURCES →
+        </Link>
+        <Link
+          href="/cryoarchive"
+          className="font-[var(--font-display)] text-xs tracking-[3px] uppercase px-6 py-3 bg-panel border border-border text-dim hover:text-foreground hover:border-accent transition-colors no-underline"
+        >
+          OPEN DASHBOARD →
+        </Link>
+      </div>
+    </main>
+  );
+}
+
+function Step({
+  number,
+  title,
+  description,
+  href,
+  cta,
+  internal,
+}: {
+  number: string;
+  title: string;
+  description: string;
+  href: string;
+  cta: string;
+  internal?: boolean;
+}) {
+  const Component = internal ? Link : "a";
+  const externalProps = internal
+    ? {}
+    : { target: "_blank", rel: "noopener noreferrer" };
+
+  return (
+    <Component
+      href={href}
+      {...externalProps}
+      className="cryo-panel p-6 hover:border-accent transition-colors no-underline group"
+    >
+      <div className="flex items-start gap-4">
+        <div className="font-[var(--font-display)] text-2xl font-black text-accent/20 shrink-0">
+          {number}
+        </div>
+        <div className="flex-1">
+          <div className="font-[var(--font-display)] text-xs tracking-[3px] text-accent group-hover:glow-accent mb-2">
+            {title}
+          </div>
+          <p className="text-dim text-sm leading-relaxed mb-3">
+            {description}
+          </p>
+          <div className="font-[var(--font-display)] text-[0.6rem] tracking-[2px] text-accent2 group-hover:glow-accent2">
+            {cta} →
+          </div>
+        </div>
+      </div>
+    </Component>
+  );
+}
+
+function ContributionPath({
+  icon,
+  title,
+  description,
+}: {
+  icon: string;
+  title: string;
+  description: string;
+}) {
+  return (
+    <div className="cryo-panel p-5">
+      <div className="text-2xl mb-3" aria-hidden="true">
+        {icon}
+      </div>
+      <div className="font-[var(--font-display)] text-xs tracking-[3px] text-accent mb-2">
+        {title}
+      </div>
+      <p className="text-dim text-sm leading-relaxed">{description}</p>
+    </div>
+  );
+}
+
+function CreditLine({
+  label,
+  name,
+  href,
+}: {
+  label: string;
+  name: string;
+  href: string;
+}) {
+  return (
+    <div className="flex items-center gap-3 text-sm">
+      <span className="font-[var(--font-display)] text-[0.6rem] tracking-[3px] text-dim shrink-0">
+        {label}
+      </span>
+      <span className="h-px flex-1 bg-border" />
+      <a
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-accent hover:glow-accent"
+      >
+        {name}
+      </a>
+    </div>
+  );
+}

--- a/src/app/community/loading.tsx
+++ b/src/app/community/loading.tsx
@@ -1,0 +1,64 @@
+export default function CommunityLoading() {
+  return (
+    <main className="max-w-4xl mx-auto px-4 sm:px-8 py-8 sm:py-16 animate-pulse">
+      {/* Hero */}
+      <div className="text-center mb-12">
+        <div className="h-10 w-64 bg-panel mx-auto mb-4 rounded" />
+        <div className="h-4 w-96 bg-panel mx-auto rounded" />
+      </div>
+
+      {/* Section */}
+      <div className="h-3 w-36 bg-border mb-4 rounded" />
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-12">
+        {[1, 2, 3, 4].map((i) => (
+          <div key={i} className="cryo-panel p-5 sm:p-6">
+            <div className="flex items-center gap-3 mb-2">
+              <div className="w-6 h-6 bg-border rounded shrink-0" />
+              <div className="h-4 w-32 bg-border rounded" />
+            </div>
+            <div className="h-3 w-full bg-border mb-1.5 rounded" />
+            <div className="h-3 w-4/5 bg-border rounded" />
+          </div>
+        ))}
+      </div>
+
+      {/* Section */}
+      <div className="h-3 w-32 bg-border mb-4 rounded" />
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 mb-12">
+        {[1, 2, 3, 4, 5, 6].map((i) => (
+          <div key={i} className="cryo-panel p-5">
+            <div className="flex items-center gap-3 mb-2">
+              <div className="w-6 h-6 bg-border rounded shrink-0" />
+              <div className="h-4 w-28 bg-border rounded" />
+            </div>
+            <div className="h-3 w-full bg-border mb-1.5 rounded" />
+            <div className="h-3 w-3/4 bg-border rounded" />
+          </div>
+        ))}
+      </div>
+
+      {/* Section */}
+      <div className="h-3 w-40 bg-border mb-4 rounded" />
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-12">
+        {[1, 2].map((i) => (
+          <div key={i} className="cryo-panel p-5 sm:p-6">
+            <div className="flex items-center gap-3 mb-2">
+              <div className="w-6 h-6 bg-border rounded shrink-0" />
+              <div className="h-4 w-36 bg-border rounded" />
+            </div>
+            <div className="h-3 w-full bg-border mb-1.5 rounded" />
+            <div className="h-3 w-2/3 bg-border rounded" />
+          </div>
+        ))}
+      </div>
+
+      {/* Developer section */}
+      <div className="h-3 w-32 bg-border mb-4 rounded" />
+      <div className="cryo-panel p-5 sm:p-6">
+        <div className="h-4 w-40 bg-border mb-3 rounded" />
+        <div className="h-3 w-full bg-border mb-2 rounded" />
+        <div className="h-3 w-3/4 bg-border rounded" />
+      </div>
+    </main>
+  );
+}

--- a/src/app/community/page.tsx
+++ b/src/app/community/page.tsx
@@ -1,0 +1,245 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { URLS, SITE_URL } from "@/lib/urls";
+
+export const metadata: Metadata = {
+  title: "Community Resources",
+  description:
+    "Links, tools, and resources for the Breachers of Tomorrow community — Discord, wiki, research docs, developer tools, and more.",
+  openGraph: {
+    title: "Community Resources // BREACHER.NET",
+    description:
+      "Links, tools, and resources for the Breachers of Tomorrow community.",
+    url: `${SITE_URL}/community`,
+  },
+};
+
+export default function CommunityPage() {
+  return (
+    <main className="max-w-5xl mx-auto px-4 sm:px-8 py-8 sm:py-16">
+      {/* Hero */}
+      <div className="text-center mb-12">
+        <h1 className="font-[var(--font-display)] text-2xl sm:text-4xl font-black text-accent glow-accent tracking-[6px] mb-4">
+          COMMUNITY RESOURCES
+        </h1>
+        <p className="text-dim text-sm sm:text-base tracking-[2px] max-w-2xl mx-auto">
+          EVERYTHING YOU NEED TO JOIN THE BREACH PROTOCOL EFFORT
+        </p>
+      </div>
+
+      {/* Primary Community Hubs */}
+      <section className="mb-12">
+        <div className="section-title">COMMUNITY HUBS</div>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <ResourceCard
+            icon="💬"
+            title="DISCORD"
+            description="The heart of Breachers of Tomorrow. 1,000+ members solving puzzles, sharing discoveries, and coordinating research."
+            href={URLS.discord}
+            cta="JOIN SERVER"
+            accent
+          />
+          <ResourceCard
+            icon="📖"
+            title="WIKI"
+            description="Marathon lore, sector documentation, character profiles, ARG timeline, and community research."
+            href={URLS.wiki}
+            cta="OPEN WIKI"
+            accent
+          />
+          <ResourceCard
+            icon="📋"
+            title="COMMUNITY DOC"
+            description="Current objectives, active research threads, and coordination for the Breach Protocol effort."
+            href={URLS.communityDoc}
+            cta="VIEW DOC"
+          />
+          <ResourceCard
+            icon="💡"
+            title="DISCUSSIONS"
+            description="GitHub Discussions for asynchronous Q&A, ideas, and community conversations."
+            href={URLS.discussions}
+            cta="JOIN DISCUSSION"
+          />
+        </div>
+      </section>
+
+      {/* Trackers & Data */}
+      <section className="mb-12">
+        <div className="section-title">TRACKERS &amp; DATA</div>
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          <ResourceCard
+            icon="📡"
+            title="DASHBOARD"
+            description="Live kill count, sector states, ship date countdown, and kill rate chart."
+            href="/cryoarchive"
+            cta="OPEN DASHBOARD"
+            internal
+          />
+          <ResourceCard
+            icon="📷"
+            title="CAMERAS"
+            description="CCTV stabilization levels, alerts, and stabilization history chart."
+            href="/cryoarchive/cameras"
+            cta="VIEW CAMERAS"
+            internal
+          />
+          <ResourceCard
+            icon="🗺️"
+            title="MAPS"
+            description="Interactive terminal maps for Perimeter, Dire Marsh, and Outpost."
+            href="/cryoarchive/maps"
+            cta="EXPLORE MAPS"
+            internal
+          />
+          <ResourceCard
+            icon="📂"
+            title="INDEX ARCHIVE"
+            description="1,200+ cryoarchive entries — types, lock status, and content data."
+            href="/cryoarchive/index"
+            cta="BROWSE INDEX"
+            internal
+          />
+          <ResourceCard
+            icon="🔄"
+            title="SITE CHANGES"
+            description="Detected deployments and build changes on cryoarchive.systems."
+            href="/cryoarchive/changes"
+            cta="VIEW CHANGES"
+            internal
+          />
+          <ResourceCard
+            icon="🌱"
+            title="WINNOWER GARDEN"
+            description="Comprehensive historical ARG data going back to the beginning. If you need older data, Winnower has it."
+            href={URLS.winnower}
+            cta="VIEW ARCHIVE"
+          />
+        </div>
+      </section>
+
+      {/* External Resources */}
+      <section className="mb-12">
+        <div className="section-title">EXTERNAL RESOURCES</div>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <ResourceCard
+            icon="🌐"
+            title="CRYOARCHIVE"
+            description="The official in-universe site this community tracks. Sectors, cameras, terminal maps, and the kill counter."
+            href={URLS.cryoarchive}
+            cta="VISIT SITE"
+          />
+          <ResourceCard
+            icon="🪐"
+            title="TAU CETI WORLD"
+            description="Community project exploring connections between the Marathon ARG and broader universe."
+            href={URLS.tauCeti}
+            cta="EXPLORE"
+          />
+        </div>
+      </section>
+
+      {/* For Developers */}
+      <section className="mb-12">
+        <div className="section-title">FOR DEVELOPERS</div>
+        <div className="cryo-panel p-6 sm:p-8">
+          <p className="text-dim text-sm leading-relaxed mb-4">
+            breacher.net is open source. Built with Next.js 16, React 19,
+            TypeScript, Tailwind v4, and PostgreSQL. Contributions welcome.
+          </p>
+          <div className="flex flex-wrap gap-4">
+            <a
+              href={URLS.breacherNetRepo}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-[var(--font-display)] text-[0.6rem] tracking-[2px] uppercase px-4 py-2.5 bg-accent/10 border border-accent text-accent hover:bg-accent/20 transition-colors no-underline inline-flex items-center gap-2"
+            >
+              <svg
+                className="w-4 h-4"
+                fill="currentColor"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
+                <path
+                  fillRule="evenodd"
+                  d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"
+                  clipRule="evenodd"
+                />
+              </svg>
+              VIEW SOURCE
+            </a>
+            <a
+              href={URLS.github}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-[var(--font-display)] text-[0.6rem] tracking-[2px] uppercase px-4 py-2.5 bg-panel border border-border text-dim hover:text-foreground hover:border-accent transition-colors no-underline"
+            >
+              GITHUB ORG
+            </a>
+          </div>
+        </div>
+      </section>
+
+      {/* Bottom nav */}
+      <div className="flex flex-wrap gap-4 justify-center">
+        <Link
+          href="/about"
+          className="font-[var(--font-display)] text-xs tracking-[3px] uppercase px-6 py-3 bg-accent/10 border border-accent text-accent hover:bg-accent/20 transition-colors no-underline"
+        >
+          ABOUT US →
+        </Link>
+        <Link
+          href="/"
+          className="font-[var(--font-display)] text-xs tracking-[3px] uppercase px-6 py-3 bg-panel border border-border text-dim hover:text-foreground hover:border-accent transition-colors no-underline"
+        >
+          HOME →
+        </Link>
+      </div>
+    </main>
+  );
+}
+
+function ResourceCard({
+  icon,
+  title,
+  description,
+  href,
+  cta,
+  internal,
+  accent,
+}: {
+  icon: string;
+  title: string;
+  description: string;
+  href: string;
+  cta: string;
+  internal?: boolean;
+  accent?: boolean;
+}) {
+  const Component = internal ? Link : "a";
+  const externalProps = internal
+    ? {}
+    : { target: "_blank", rel: "noopener noreferrer" };
+
+  return (
+    <Component
+      href={href}
+      {...externalProps}
+      className={`cryo-panel p-6 flex items-start gap-4 hover:border-accent transition-colors no-underline group ${accent ? "border-accent/30" : ""
+        }`}
+    >
+      <div className="text-2xl shrink-0 mt-0.5" aria-hidden="true">
+        {icon}
+      </div>
+      <div className="flex-1 min-w-0">
+        <div className="font-[var(--font-display)] text-xs tracking-[3px] text-accent group-hover:glow-accent mb-1.5">
+          {title}
+        </div>
+        <p className="text-dim text-sm leading-relaxed mb-2">{description}</p>
+        <div className="font-[var(--font-display)] text-[0.55rem] tracking-[2px] text-accent2 group-hover:glow-accent2">
+          {cta} →
+        </div>
+      </div>
+    </Component>
+  );
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -42,5 +42,17 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: "daily",
       priority: 0.6,
     },
+    {
+      url: `${baseUrl}/about`,
+      lastModified: now,
+      changeFrequency: "monthly",
+      priority: 0.6,
+    },
+    {
+      url: `${baseUrl}/community`,
+      lastModified: now,
+      changeFrequency: "monthly",
+      priority: 0.6,
+    },
   ];
 }

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -30,6 +30,8 @@ const NAV_SECTIONS: NavSection[] = [
   {
     label: "BREACHER.NET",
     links: [
+      { href: "/about", label: "About" },
+      { href: "/community", label: "Community" },
       { href: URLS.wiki, label: "Wiki", external: true },
       { href: URLS.discord, label: "Discord", external: true },
       {

--- a/src/lib/urls.ts
+++ b/src/lib/urls.ts
@@ -46,6 +46,14 @@ export const URLS = {
   /** Breachers of Tomorrow GitHub org */
   github: "https://github.com/breachers-of-tomorrow",
 
+  /** GitHub Discussions — community Q&A */
+  discussions:
+    "https://github.com/breachers-of-tomorrow/community/discussions",
+
+  /** breacher-net repo — for contributors */
+  breacherNetRepo:
+    "https://github.com/breachers-of-tomorrow/breacher-net",
+
   /** CrowdTypical — original tracker author */
   crowdTypical: "https://github.com/CrowdTypical",
 } as const;


### PR DESCRIPTION
## Summary

Adds two new static pages — **About** and **Community** — and integrates them into the site navigation, sitemap, and loading skeleton system.

Closes #30, closes #36, partially addresses #29 (nav restructure)

---

### `/about` (#36)
Community overview page with:
- Hero with tagline
- "What Is This?" intro section
- "Get Started" — 4-step onboarding (Discord → Dashboard → Community Doc → Community page)
- "Ways to Contribute" — 6 paths (ARG Research, Code & Tools, Writing & Docs, Design & Branding, Community Building, Data & Analysis)
- Community structure (~15 Keepers)
- Credits (CrowdTypical, Winnower, BoT)

### `/community` (#30)
Resource links hub organized into sections:
- **Community Hubs** — Discord, Wiki, Community Doc, Discussions
- **Trackers & Data** — Dashboard, Cameras, Maps, Index, Changes, Winnower
- **External Resources** — Cryoarchive, Tau Ceti
- **For Developers** — Source repo, GitHub org

### Navigation (#29 partial)
- Added About and Community as internal links under the BREACHER.NET section
- Both desktop tabs and mobile menu updated automatically via `NAV_SECTIONS`

### Other
- `urls.ts`: Added `discussions` and `breacherNetRepo` URLs
- `sitemap.ts`: Both routes added (monthly, priority 0.6)
- Loading skeletons for both routes matching existing design patterns

### Build
- ✅ Lint clean
- ✅ Build clean — both pages statically generated