### PR TITLE
feat: chart UX overhaul, weapons DB, DOCUMENT type, badge fix

### DIFF
--- a/poller/poll_index.py
+++ b/poller/poll_index.py
@@ -191,6 +191,8 @@ def parse_rsc_entries(html: str) -> list[dict]:
                 entry_type = "AUDIO"
             elif "video" in mime:
                 entry_type = "VIDEO"
+            elif "pdf" in mime:
+                entry_type = "DOCUMENT"
             else:
                 entry_type = "MEDIA"
 

--- a/src/app/api/index-entries/route.ts
+++ b/src/app/api/index-entries/route.ts
@@ -40,7 +40,9 @@ export async function GET(request: Request) {
         COUNT(*) FILTER (WHERE entry_type = 'IMAGE') AS images,
         COUNT(*) FILTER (WHERE entry_type = 'TEXT') AS texts,
         COUNT(*) FILTER (WHERE entry_type = 'VIDEO') AS videos,
-        COUNT(*) FILTER (WHERE entry_type = 'AUDIO') AS audio
+        COUNT(*) FILTER (WHERE entry_type = 'AUDIO') AS audio,
+        COUNT(*) FILTER (WHERE entry_type = 'DOCUMENT') AS documents,
+        COUNT(*) FILTER (WHERE entry_type = 'MEDIA') AS media
       FROM index_entries
     `);
 
@@ -88,6 +90,8 @@ export async function GET(request: Request) {
                     TEXT: Number(stats.texts),
                     VIDEO: Number(stats.videos),
                     AUDIO: Number(stats.audio),
+                    DOCUMENT: Number(stats.documents),
+                    MEDIA: Number(stats.media),
                 },
             },
             entries: entriesResult.rows,

--- a/src/app/community/page.tsx
+++ b/src/app/community/page.tsx
@@ -137,6 +137,13 @@ export default function CommunityPage() {
             href={URLS.tauCeti}
             cta="EXPLORE"
           />
+          <ResourceCard
+            icon="🔫"
+            title="WEAPONS DATABASE"
+            description="Community-built weapon and mod tracker — stats, attachments, and up-to-date loadout information."
+            href={URLS.weaponsDb}
+            cta="VIEW WEAPONS"
+          />
         </div>
       </section>
 

--- a/src/app/cryoarchive/DashboardClient.tsx
+++ b/src/app/cryoarchive/DashboardClient.tsx
@@ -355,7 +355,7 @@ function Badge({
   const classes = on
     ? "border-accent2 text-accent2 bg-accent2/[0.08] box-glow-accent2"
     : partial
-      ? "border-accent text-accent bg-accent/5"
+      ? "border-border text-dim/60 bg-transparent"
       : "border-border text-dim";
 
   return (

--- a/src/app/cryoarchive/index/IndexArchiveClient.tsx
+++ b/src/app/cryoarchive/index/IndexArchiveClient.tsx
@@ -16,6 +16,8 @@ interface IndexStats {
         TEXT: number;
         VIDEO: number;
         AUDIO: number;
+        DOCUMENT: number;
+        MEDIA: number;
     };
 }
 
@@ -46,7 +48,7 @@ interface IndexApiResponse {
     source?: "database" | "live-scrape";
 }
 
-type FilterTab = "all" | "unlocked" | "new" | "IMAGE" | "TEXT" | "VIDEO" | "AUDIO";
+type FilterTab = "all" | "unlocked" | "new" | "IMAGE" | "TEXT" | "VIDEO" | "AUDIO" | "DOCUMENT" | "MEDIA";
 
 /* ------------------------------------------------------------------ */
 /*  Constants                                                          */
@@ -175,11 +177,17 @@ export function IndexArchiveClient() {
                         <StatCard label="TEXT" value={stats.types.TEXT} color="text-accent glow-accent" />
                         <StatCard label="VIDEO" value={stats.types.VIDEO} color="text-warn glow-warn" />
                         <StatCard label="AUDIO" value={stats.types.AUDIO} color="text-danger glow-danger" />
+                        {stats.types.DOCUMENT > 0 && (
+                            <StatCard label="DOCUMENT" value={stats.types.DOCUMENT} color="text-purple-400 glow-accent" />
+                        )}
+                        {stats.types.MEDIA > 0 && (
+                            <StatCard label="MEDIA" value={stats.types.MEDIA} color="text-dim" />
+                        )}
                     </div>
 
                     {/* Filter Tabs */}
                     <div className="flex flex-wrap gap-2 mb-6">
-                        {(["all", "unlocked", "new", "IMAGE", "TEXT", "VIDEO", "AUDIO"] as FilterTab[]).map((tab) => {
+                        {(["all", "unlocked", "new", "IMAGE", "TEXT", "VIDEO", "AUDIO", "DOCUMENT", "MEDIA"] as FilterTab[]).map((tab) => {
                             const isActive = filter === tab;
                             const count = tab === "all"
                                 ? stats.total
@@ -188,6 +196,8 @@ export function IndexArchiveClient() {
                                     : tab === "new"
                                         ? newCount
                                         : stats.types[tab as keyof typeof stats.types] ?? 0;
+                            // Hide DOCUMENT and MEDIA tabs when count is 0
+                            if ((tab === "DOCUMENT" || tab === "MEDIA") && count === 0) return null;
                             return (
                                 <button
                                     key={tab}
@@ -267,6 +277,8 @@ const TYPE_COLORS: Record<string, string> = {
     TEXT: "text-accent",
     VIDEO: "text-warn",
     AUDIO: "text-danger",
+    DOCUMENT: "text-purple-400",
+    MEDIA: "text-dim",
 };
 
 function EntryRow({ entry, isNew, isExpanded, onToggle }: {
@@ -375,6 +387,30 @@ function EntryContent({ data: cd, entryId }: { data: EntryContentData; entryId: 
                 {(cd.altFilename || cd.alt) && (
                     <div className="text-dim text-[0.6rem] mt-1.5 tracking-[1px]">
                         {cd.altFilename ?? cd.alt}
+                    </div>
+                )}
+            </div>
+        );
+    }
+
+    // PDF / Document
+    if (cd.url && cd.mimeType === "application/pdf") {
+        return (
+            <div className="py-2">
+                <a
+                    href={cd.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-2 text-purple-400 hover:text-purple-300 transition-colors"
+                >
+                    <span className="text-lg">📄</span>
+                    <span className="tracking-[1px] text-[0.7rem]">
+                        {cd.altFilename ?? cd.alt ?? "VIEW DOCUMENT"}
+                    </span>
+                </a>
+                {(cd.altFilename || cd.alt) && cd.altFilename !== cd.alt && (
+                    <div className="text-dim text-[0.6rem] mt-1 tracking-[1px]">
+                        {cd.alt}
                     </div>
                 )}
             </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -207,6 +207,25 @@ export default async function HomePage() {
             →
           </div>
         </a>
+        <a
+          href={URLS.weaponsDb}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="cryo-panel p-6 flex items-center gap-4 hover:border-accent transition-colors no-underline group"
+        >
+          <div className="text-3xl" aria-hidden="true">🔫</div>
+          <div>
+            <div className="font-[var(--font-display)] text-xs tracking-[3px] text-accent group-hover:glow-accent mb-1">
+              WEAPONS DATABASE
+            </div>
+            <div className="text-sm text-dim">
+              Community weapon and mod tracker with loadout info
+            </div>
+          </div>
+          <div className="ml-auto text-accent2 font-[var(--font-display)] text-lg group-hover:translate-x-1 transition-transform">
+            →
+          </div>
+        </a>
       </div>
 
       {/* Footer */}

--- a/src/components/KillCountChart.tsx
+++ b/src/components/KillCountChart.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { URLS } from "@/lib/urls";
 import {
   ResponsiveContainer,
-  AreaChart,
+  ComposedChart,
   Area,
+  Line,
   XAxis,
   YAxis,
   Tooltip,
@@ -14,7 +15,10 @@ import {
 
 interface DataPoint {
   timestamp: string;
+  ts: number;
   value: number;
+  kpm: number | null;
+  kpmSmooth: number | null;
   label: string;
 }
 
@@ -23,8 +27,45 @@ interface HistoryRow {
   kill_count: number;
 }
 
-function formatAxis(ts: string): string {
+/* ------------------------------------------------------------------ */
+/*  Time range options                                                 */
+/* ------------------------------------------------------------------ */
+
+const RANGES = [
+  { label: "6H", hours: 6 },
+  { label: "24H", hours: 24 },
+  { label: "3D", hours: 72 },
+  { label: "7D", hours: 168 },
+  { label: "ALL", hours: 0 },
+] as const;
+
+type RangeLabel = (typeof RANGES)[number]["label"];
+
+const DEFAULT_RANGE: RangeLabel = "24H";
+const MAX_CHART_POINTS = 300;
+const KPM_SMOOTH_WINDOW = 5;
+
+/* ------------------------------------------------------------------ */
+/*  Formatting helpers                                                 */
+/* ------------------------------------------------------------------ */
+
+function spansMultipleDays(data: DataPoint[]): boolean {
+  if (data.length < 2) return false;
+  const first = new Date(data[0].timestamp).toLocaleDateString();
+  const last = new Date(data[data.length - 1].timestamp).toLocaleDateString();
+  return first !== last;
+}
+
+function formatAxis(ts: string, multiDay: boolean): string {
   const d = new Date(ts);
+  if (multiDay) {
+    return d.toLocaleString("en-US", {
+      month: "short",
+      day: "numeric",
+      hour: "numeric",
+      hour12: true,
+    });
+  }
   return d.toLocaleTimeString("en-US", {
     hour: "numeric",
     minute: "2-digit",
@@ -49,15 +90,56 @@ function formatKills(n: number): string {
   return n.toLocaleString();
 }
 
+/* ------------------------------------------------------------------ */
+/*  Data processing                                                    */
+/* ------------------------------------------------------------------ */
+
+/** Downsample keeping first, last, and evenly-spaced middle points. */
+function downsample(points: DataPoint[], maxPoints: number): DataPoint[] {
+  if (points.length <= maxPoints) return points;
+  const result: DataPoint[] = [points[0]];
+  const step = (points.length - 1) / (maxPoints - 1);
+  for (let i = 1; i < maxPoints - 1; i++) {
+    result.push(points[Math.round(i * step)]);
+  }
+  result.push(points[points.length - 1]);
+  return result;
+}
+
+/** Simple moving-average smoothing for KPM. */
+function smoothKpm(points: DataPoint[], window: number): DataPoint[] {
+  return points.map((p, i) => {
+    if (p.kpm === null) return p;
+    const half = Math.floor(window / 2);
+    const start = Math.max(0, i - half);
+    const end = Math.min(points.length, i + half + 1);
+    const values: number[] = [];
+    for (let j = start; j < end; j++) {
+      if (points[j].kpm !== null) values.push(points[j].kpm!);
+    }
+    const avg =
+      values.length > 0
+        ? Math.round(values.reduce((a, b) => a + b, 0) / values.length)
+        : null;
+    return { ...p, kpmSmooth: avg };
+  });
+}
+
+/* ------------------------------------------------------------------ */
+/*  Component                                                          */
+/* ------------------------------------------------------------------ */
+
 export function KillCountChart() {
-  const [data, setData] = useState<DataPoint[]>([]);
+  const [allData, setAllData] = useState<DataPoint[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [range, setRange] = useState<RangeLabel>(DEFAULT_RANGE);
+  const [showKpm, setShowKpm] = useState(true);
 
   useEffect(() => {
     async function load() {
       try {
-        const res = await fetch("/api/state/history?limit=288");
+        const res = await fetch("/api/state/history?limit=1000");
         if (!res.ok) throw new Error(`API returned ${res.status}`);
         const json = await res.json();
 
@@ -67,29 +149,70 @@ export function KillCountChart() {
           return;
         }
 
-        // Sort oldest → newest
         const sorted = [...rows].sort(
           (a, b) =>
             new Date(a.captured_at).getTime() -
             new Date(b.captured_at).getTime(),
         );
 
-        setData(
-          sorted.map((r) => ({
+        const points: DataPoint[] = sorted.map((r, i) => {
+          let kpm: number | null = null;
+          if (i > 0) {
+            const prev = sorted[i - 1];
+            const t1 = new Date(prev.captured_at).getTime();
+            const t2 = new Date(r.captured_at).getTime();
+            const mins = (t2 - t1) / 60_000;
+            if (mins > 0 && r.kill_count > prev.kill_count) {
+              kpm = Math.round((r.kill_count - prev.kill_count) / mins);
+            }
+          }
+          return {
             timestamp: r.captured_at,
+            ts: new Date(r.captured_at).getTime(),
             value: r.kill_count,
+            kpm,
+            kpmSmooth: null,
             label: formatTooltipTime(r.captured_at),
-          })),
-        );
+          };
+        });
+
+        setAllData(points);
       } catch (err) {
         setError(err instanceof Error ? err.message : "Failed to load chart");
       } finally {
         setLoading(false);
       }
     }
-
     load();
   }, []);
+
+  /** Filter → downsample → smooth, recomputed when range or data changes. */
+  const chartData = useMemo(() => {
+    if (allData.length === 0) return [];
+    const cfg = RANGES.find((r) => r.label === range)!;
+    let filtered: DataPoint[];
+    if (cfg.hours === 0) {
+      filtered = allData;
+    } else {
+      const cutoff = Date.now() - cfg.hours * 3_600_000;
+      filtered = allData.filter((d) => d.ts >= cutoff);
+      if (filtered.length < 2) filtered = allData;
+    }
+    return smoothKpm(downsample(filtered, MAX_CHART_POINTS), KPM_SMOOTH_WINDOW);
+  }, [allData, range]);
+
+  /** Only enable range buttons when we actually have enough data. */
+  const availableRanges = useMemo(() => {
+    if (allData.length === 0) return new Set<RangeLabel>();
+    const hoursAvail = (Date.now() - allData[0].ts) / 3_600_000;
+    const set = new Set<RangeLabel>(["ALL"]);
+    for (const r of RANGES) {
+      if (r.hours === 0 || hoursAvail >= r.hours * 0.5) set.add(r.label);
+    }
+    return set;
+  }, [allData]);
+
+  /* ---- Loading / error states ---- */
 
   if (loading) {
     return (
@@ -101,7 +224,7 @@ export function KillCountChart() {
     );
   }
 
-  if (error || data.length === 0) {
+  if (error || allData.length === 0) {
     return (
       <div className="cryo-panel p-5 h-[300px] flex flex-col items-center justify-center gap-4">
         <div className="text-dim text-sm tracking-[2px]">
@@ -119,13 +242,68 @@ export function KillCountChart() {
     );
   }
 
+  /* ---- Render ---- */
+
+  const multiDay = spansMultipleDays(chartData);
+  const hasKpm =
+    showKpm && chartData.some((d) => d.kpmSmooth !== null && d.kpmSmooth! > 0);
+
   return (
-    <div className="cryo-panel p-4 sm:p-5" role="img" aria-label="Kill count over time chart showing UESC kill count trends">
-      <div className="h-[280px] sm:h-[300px]">
+    <div
+      className="cryo-panel p-4 sm:p-5"
+      role="img"
+      aria-label="Kill count over time chart"
+    >
+      {/* Header bar: title + controls */}
+      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3 mb-4">
+        <div className="font-[var(--font-display)] text-[0.65rem] tracking-[3px] text-dim">
+          KILL COUNT OVER TIME
+        </div>
+        <div className="flex items-center gap-3 flex-wrap">
+          {/* KPM toggle */}
+          <button
+            onClick={() => setShowKpm((v) => !v)}
+            className={`font-[var(--font-display)] text-[0.55rem] tracking-[2px] px-2 py-1 border transition-colors ${
+              showKpm
+                ? "border-orange-500/50 text-orange-400 bg-orange-500/10"
+                : "border-border text-dim hover:text-text-body"
+            }`}
+            title={showKpm ? "Hide kills/min rate" : "Show kills/min rate"}
+          >
+            KILLS/MIN
+          </button>
+          {/* Time range */}
+          <div className="flex gap-1">
+            {RANGES.map((r) => {
+              const ok = availableRanges.has(r.label);
+              const on = range === r.label;
+              return (
+                <button
+                  key={r.label}
+                  onClick={() => ok && setRange(r.label)}
+                  disabled={!ok}
+                  className={`font-[var(--font-display)] text-[0.55rem] tracking-[1px] px-2 py-1 border transition-colors ${
+                    on
+                      ? "border-accent text-accent bg-accent/10"
+                      : ok
+                        ? "border-border text-dim hover:text-text-body hover:border-border"
+                        : "border-border/50 text-dim/30 cursor-not-allowed"
+                  }`}
+                >
+                  {r.label}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+
+      {/* Chart */}
+      <div className="h-[300px] sm:h-[340px]">
         <ResponsiveContainer width="100%" height="100%">
-          <AreaChart
-            data={data}
-            margin={{ top: 10, right: 10, left: 0, bottom: 0 }}
+          <ComposedChart
+            data={chartData}
+            margin={{ top: 5, right: hasKpm ? 50 : 10, left: 0, bottom: 0 }}
           >
             <defs>
               <linearGradient id="killGradient" x1="0" y1="0" x2="0" y2="1">
@@ -140,15 +318,16 @@ export function KillCountChart() {
             />
             <XAxis
               dataKey="timestamp"
-              tickFormatter={formatAxis}
+              tickFormatter={(ts) => formatAxis(ts, multiDay)}
               stroke="#5A7A8A"
               tick={{ fontSize: 10, fill: "#5A7A8A" }}
               axisLine={{ stroke: "#1A4660" }}
               tickLine={{ stroke: "#1A4660" }}
               interval="preserveStartEnd"
-              minTickGap={60}
+              minTickGap={multiDay ? 80 : 60}
             />
             <YAxis
+              yAxisId="left"
               tickFormatter={formatKills}
               stroke="#5A7A8A"
               tick={{ fontSize: 10, fill: "#5A7A8A" }}
@@ -157,12 +336,31 @@ export function KillCountChart() {
               width={55}
               domain={["dataMin - 100000", "dataMax + 100000"]}
             />
+            {hasKpm && (
+              <YAxis
+                yAxisId="right"
+                orientation="right"
+                tickFormatter={(v) => `${v}`}
+                stroke="#5A7A8A"
+                tick={{ fontSize: 10, fill: "#FF6B35" }}
+                axisLine={{ stroke: "#1A4660" }}
+                tickLine={{ stroke: "#1A4660" }}
+                width={40}
+              />
+            )}
             <Tooltip
               labelFormatter={(label) => formatTooltipTime(label as string)}
-              formatter={(value) => [
-                Number(value).toLocaleString(),
-                "Kill Count",
-              ]}
+              formatter={(value, name) => {
+                const v = Number(value);
+                if (name === "Kill Count")
+                  return [v.toLocaleString(), "Kill Count"];
+                if (name === "Kills/min")
+                  return [
+                    `${v.toLocaleString()} kills/min`,
+                    "Rate",
+                  ];
+                return [String(value), String(name)];
+              }}
               contentStyle={{
                 backgroundColor: "#0A2A35",
                 border: "1px solid #1A4660",
@@ -178,8 +376,10 @@ export function KillCountChart() {
               }}
             />
             <Area
+              yAxisId="left"
               type="monotone"
               dataKey="value"
+              name="Kill Count"
               stroke="#FF3344"
               strokeWidth={2}
               fill="url(#killGradient)"
@@ -191,7 +391,21 @@ export function KillCountChart() {
                 strokeWidth: 2,
               }}
             />
-          </AreaChart>
+            {hasKpm && (
+              <Line
+                yAxisId="right"
+                type="monotone"
+                dataKey="kpmSmooth"
+                name="Kills/min"
+                stroke="#FF6B35"
+                strokeWidth={1.5}
+                strokeOpacity={0.7}
+                dot={false}
+                activeDot={{ r: 3, fill: "#FF6B35", stroke: "#FF6B35" }}
+                connectNulls
+              />
+            )}
+          </ComposedChart>
         </ResponsiveContainer>
       </div>
     </div>

--- a/src/lib/urls.ts
+++ b/src/lib/urls.ts
@@ -35,6 +35,9 @@ export const URLS = {
   /** Tau Ceti community project */
   tauCeti: "https://tauceti.world",
 
+  /** Marathon Weapons Database — community weapon/mod tracker */
+  weaponsDb: "https://d7dfb5c3f756e5dd.vercel-dns-017.com",
+
   /** Cryoarchive source site */
   cryoarchive: "https://cryoarchive.systems",
 


### PR DESCRIPTION
## Summary

Four improvements across the dashboard, chart, index, and community pages.

## Changes

### Kill Count Chart — UX Overhaul
- **Time range selector**: 6H, 24H (default), 3D, 7D, ALL buttons. Only enables ranges that have sufficient data.
- **Kills/min toggle**: Orange toggle button to show/hide the KPM rate overlay. On by default.
- **Smoothed line**: KPM rendered as a smoothed Line (5-point moving average) instead of raw Scatter dots — much cleaner visualization.
- **Downsampling**: Caps at 300 data points for performance; evenly samples longer ranges.
- **Smart axis**: Includes date labels when data spans multiple days. Fetches 1000 rows (was 288) for full history.
- **Header bar**: \"KILL COUNT OVER TIME\" title with inline controls.

### Weapons Database — Community Project Card
- New external link in `urls.ts` for community weapons/mod tracker (`d7dfb5c3f756e5dd.vercel-dns-017.com`)
- Card added to community page External Resources section (🔫 WEAPONS DATABASE)
- Card added to homepage Community section

### Index Archive — DOCUMENT Type Support
- **Poller**: `application/pdf` → `DOCUMENT` type classification (was falling through to generic `MEDIA`)
- **API**: Counts DOCUMENT and MEDIA types in stats response
- **Frontend**: Purple color for DOCUMENT entries, filter tab, inline PDF link viewer
- DOCUMENT/MEDIA tabs hidden when count is 0

### Dashboard — Badge Contrast Fix
- COMPLETED badge when sector is unlocked-but-not-completed now uses grey (`border-border text-dim/60`) instead of accent blue
- Much more obvious visual distinction between \"in progress\" and \"done\"

Refs #31