### PR TITLE
feat: add Contribute page (#60) and API docs page (#45)

### DIFF
--- a/src/app/api-docs/page.tsx
+++ b/src/app/api-docs/page.tsx
@@ -1,0 +1,538 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { SITE_URL, URLS } from "@/lib/urls";
+
+export const metadata: Metadata = {
+  title: "API Documentation",
+  description:
+    "Public API reference for breacher.net — endpoints for state, stabilization, builds, index entries, and health.",
+  openGraph: {
+    title: "API Documentation // BREACHER.NET",
+    description:
+      "Public REST API for cryoarchive state, stabilization, builds, and index data.",
+    url: `${SITE_URL}/api-docs`,
+  },
+};
+
+interface Endpoint {
+  method: string;
+  path: string;
+  description: string;
+  params?: { name: string; type: string; default?: string; description: string }[];
+  responseFields: { name: string; type: string; description: string }[];
+  example: string;
+  cache?: string;
+}
+
+const ENDPOINTS: Endpoint[] = [
+  {
+    method: "GET",
+    path: "/api/health",
+    description:
+      "Health check endpoint for monitoring. Returns database connection status and current data mode.",
+    responseFields: [
+      { name: "status", type: '"healthy" | "degraded" | "standalone"', description: "Overall service health" },
+      { name: "timestamp", type: "string (ISO 8601)", description: "Current server time" },
+      { name: "database.configured", type: "boolean", description: "Whether DATABASE_URL is set" },
+      { name: "database.connected", type: "boolean", description: "Whether the DB connection is live" },
+      { name: "database.has_data", type: "boolean", description: "Whether the poller has written data" },
+      { name: "mode", type: '"database" | "live-api"', description: "Data source mode" },
+    ],
+    example: `{
+  "status": "healthy",
+  "timestamp": "2026-03-17T12:00:00.000Z",
+  "database": {
+    "configured": true,
+    "connected": true,
+    "has_data": true
+  },
+  "mode": "database"
+}`,
+  },
+  {
+    method: "GET",
+    path: "/api/state/latest",
+    description:
+      "Returns the most recent cryoarchive state snapshot — kill count, ship date, sector states, and memory flags. Updated every 5 minutes by the poller.",
+    responseFields: [
+      { name: "data.capturedAt", type: "string (ISO 8601)", description: "When this snapshot was captured" },
+      { name: "data.killCount", type: "number", description: "Current kill counter value" },
+      { name: "data.shipDate", type: "string", description: "Displayed ship date" },
+      { name: "data.nextUpdate", type: "string", description: "Next scheduled update time" },
+      { name: "data.sectors", type: "object", description: "Sector names → status mapping" },
+      { name: "data.memoryFlags", type: "object", description: "Memory flag states" },
+      { name: "source", type: '"database"', description: "Data source" },
+    ],
+    example: `{
+  "data": {
+    "capturedAt": "2026-03-17T12:00:00.000Z",
+    "killCount": 476291,
+    "shipDate": "JUL 23 2026",
+    "nextUpdate": "...",
+    "sectors": { "perimeter": "active", ... },
+    "memoryFlags": { ... }
+  },
+  "source": "database"
+}`,
+    cache: "60s + 30s stale-while-revalidate",
+  },
+  {
+    method: "GET",
+    path: "/api/state/history",
+    description:
+      "Returns historical state snapshots with kill count, sectors, and memory flags over time. Use for charts and trend analysis.",
+    params: [
+      { name: "limit", type: "integer", default: "100", description: "Max rows to return (max 1000)" },
+      { name: "since", type: "ISO 8601 timestamp", description: "Only return snapshots after this time" },
+    ],
+    responseFields: [
+      { name: "data", type: "array", description: "Array of state snapshot rows" },
+      { name: "count", type: "number", description: "Number of rows returned" },
+      { name: "source", type: '"database"', description: "Data source" },
+    ],
+    example: `{
+  "data": [
+    {
+      "captured_at": "2026-03-17T12:00:00Z",
+      "kill_count": 476291,
+      "ship_date": "JUL 23 2026",
+      "build_version": "...",
+      "sectors": { ... },
+      "memory_flags": { ... }
+    }
+  ],
+  "count": 100,
+  "source": "database"
+}`,
+    cache: "120s + 60s stale-while-revalidate",
+  },
+  {
+    method: "GET",
+    path: "/api/stabilization/latest",
+    description:
+      "Returns the latest camera stabilization snapshot — current stabilization levels and next stabilization time.",
+    responseFields: [
+      { name: "data.capturedAt", type: "string (ISO 8601)", description: "When this snapshot was captured" },
+      { name: "data.cameras", type: "object", description: "Camera name → stabilization object mapping" },
+      { name: "data.nextStabilization", type: "string", description: "Next stabilization event time" },
+      { name: "source", type: '"database"', description: "Data source" },
+    ],
+    example: `{
+  "data": {
+    "capturedAt": "2026-03-17T12:00:00.000Z",
+    "cameras": {
+      "camera_01": { "level": 87.5, "status": "stable" }
+    },
+    "nextStabilization": "2026-03-17T13:00:00Z"
+  },
+  "source": "database"
+}`,
+    cache: "60s + 30s stale-while-revalidate",
+  },
+  {
+    method: "GET",
+    path: "/api/stabilization/history",
+    description:
+      "Returns historical stabilization snapshots. Use for charting camera stabilization levels over time.",
+    params: [
+      { name: "limit", type: "integer", default: "100", description: "Max rows to return (max 1000)" },
+      { name: "since", type: "ISO 8601 timestamp", description: "Only return snapshots after this time" },
+    ],
+    responseFields: [
+      { name: "data", type: "array", description: "Array of stabilization snapshot rows" },
+      { name: "count", type: "number", description: "Number of rows returned" },
+      { name: "source", type: '"database"', description: "Data source" },
+    ],
+    example: `{
+  "data": [
+    {
+      "captured_at": "2026-03-17T12:00:00Z",
+      "cameras": { ... },
+      "next_stabilization": "2026-03-17T13:00:00Z"
+    }
+  ],
+  "count": 100,
+  "source": "database"
+}`,
+    cache: "120s + 60s stale-while-revalidate",
+  },
+  {
+    method: "GET",
+    path: "/api/builds/latest",
+    description:
+      "Returns the most recent build/deployment event detected on cryoarchive.systems.",
+    responseFields: [
+      { name: "data.id", type: "number", description: "Build event ID" },
+      { name: "data.detected_at", type: "string (ISO 8601)", description: "When the build was detected" },
+      { name: "data.build_hash", type: "string", description: "Build hash identifier" },
+      { name: "data.build_version", type: "string", description: "Build version string" },
+      { name: "data.summary", type: "string", description: "Human-readable summary of changes" },
+      { name: "data.details", type: "object", description: "Detailed change information" },
+      { name: "data.headers", type: "object", description: "HTTP headers from the build" },
+      { name: "source", type: '"database"', description: "Data source" },
+    ],
+    example: `{
+  "data": {
+    "id": 42,
+    "detected_at": "2026-03-17T10:30:00Z",
+    "build_hash": "abc123...",
+    "build_version": "1.2.3",
+    "summary": "New build deployed",
+    "details": { ... },
+    "headers": { ... }
+  },
+  "source": "database"
+}`,
+    cache: "60s + 30s stale-while-revalidate",
+  },
+  {
+    method: "GET",
+    path: "/api/builds",
+    description:
+      "Returns a list of build/deployment change events in reverse chronological order.",
+    params: [
+      { name: "limit", type: "integer", default: "50", description: "Max rows to return (max 200)" },
+    ],
+    responseFields: [
+      { name: "data", type: "array", description: "Array of build event objects" },
+      { name: "count", type: "number", description: "Number of rows returned" },
+      { name: "source", type: '"database"', description: "Data source" },
+    ],
+    example: `{
+  "data": [
+    {
+      "id": 42,
+      "detected_at": "2026-03-17T10:30:00Z",
+      "build_hash": "abc123...",
+      "build_version": "1.2.3",
+      "summary": "New build deployed",
+      "details": { ... },
+      "headers": { ... }
+    }
+  ],
+  "count": 50,
+  "source": "database"
+}`,
+  },
+  {
+    method: "GET",
+    path: "/api/index-entries",
+    description:
+      "Returns all cryoarchive index entries with stats summary. Supports filtering by lock status and content type. Currently tracks 1,200+ entries.",
+    params: [
+      { name: "status", type: '"locked" | "unlocked" | "all"', default: '"all"', description: "Filter by lock status" },
+      { name: "type", type: '"IMAGE" | "TEXT" | "VIDEO" | "AUDIO"', description: "Filter by content type" },
+    ],
+    responseFields: [
+      { name: "stats.total", type: "number", description: "Total entries in database" },
+      { name: "stats.unlocked", type: "number", description: "Number of unlocked entries" },
+      { name: "stats.locked", type: "number", description: "Number of locked entries" },
+      { name: "stats.types", type: "object", description: "Count per type — IMAGE, TEXT, VIDEO, AUDIO, DOCUMENT, MEDIA" },
+      { name: "entries", type: "array", description: "Array of index entry objects" },
+      { name: "fetchedAt", type: "string (ISO 8601)", description: "When the query was executed" },
+      { name: "source", type: '"database"', description: "Data source" },
+    ],
+    example: `{
+  "stats": {
+    "total": 1247,
+    "unlocked": 312,
+    "locked": 935,
+    "types": {
+      "IMAGE": 856,
+      "TEXT": 203,
+      "VIDEO": 47,
+      "AUDIO": 89,
+      "DOCUMENT": 12,
+      "MEDIA": 40
+    }
+  },
+  "entries": [
+    {
+      "entry_id": "IDX-0001",
+      "entry_type": "IMAGE",
+      "status": "unlocked",
+      "first_seen": "2026-01-15T...",
+      "last_updated": "2026-03-17T...",
+      "content_data": { ... }
+    }
+  ],
+  "fetchedAt": "2026-03-17T12:00:00.000Z",
+  "source": "database"
+}`,
+    cache: "300s + 120s stale-while-revalidate",
+  },
+];
+
+export default function ApiDocsPage() {
+  return (
+    <main className="max-w-5xl mx-auto px-4 sm:px-8 py-8 sm:py-16">
+      {/* Hero */}
+      <div className="text-center mb-12">
+        <h1 className="font-[var(--font-display)] text-2xl sm:text-4xl font-black text-accent glow-accent tracking-[6px] mb-4">
+          API DOCUMENTATION
+        </h1>
+        <p className="text-dim text-sm sm:text-base tracking-[2px] max-w-2xl mx-auto mb-2">
+          PUBLIC REST API FOR CRYOARCHIVE DATA
+        </p>
+        <p className="text-dim/60 text-xs tracking-[1px] max-w-xl mx-auto">
+          All endpoints are read-only and publicly accessible. Data is updated every 5 minutes
+          by the Python poller. No authentication required.
+        </p>
+      </div>
+
+      {/* Base URL */}
+      <section className="mb-8">
+        <div className="section-title">BASE URL</div>
+        <div className="cryo-panel p-4 sm:p-6">
+          <code className="text-accent2 text-sm font-[var(--font-mono)] break-all">
+            https://breacher.net
+          </code>
+          <p className="text-dim text-xs mt-2">
+            All endpoints return JSON. Responses include a{" "}
+            <code className="text-accent2 text-[0.65rem]">source</code> field indicating the data origin.
+            Cloudflare caching respects the{" "}
+            <code className="text-accent2 text-[0.65rem]">Cache-Control</code> headers set by each endpoint.
+          </p>
+        </div>
+      </section>
+
+      {/* Quick Reference */}
+      <section className="mb-12">
+        <div className="section-title">QUICK REFERENCE</div>
+        <div className="cryo-panel overflow-x-auto">
+          <table className="w-full text-xs">
+            <thead>
+              <tr className="border-b border-border">
+                <th className="text-left font-[var(--font-display)] text-[0.6rem] tracking-[2px] text-dim px-4 py-3">METHOD</th>
+                <th className="text-left font-[var(--font-display)] text-[0.6rem] tracking-[2px] text-dim px-4 py-3">ENDPOINT</th>
+                <th className="text-left font-[var(--font-display)] text-[0.6rem] tracking-[2px] text-dim px-4 py-3 hidden sm:table-cell">DESCRIPTION</th>
+              </tr>
+            </thead>
+            <tbody>
+              {ENDPOINTS.map((ep) => (
+                <tr key={ep.path} className="border-b border-border/30 hover:bg-accent/5 transition-colors">
+                  <td className="px-4 py-2.5">
+                    <span className="font-[var(--font-display)] text-[0.6rem] tracking-[1px] text-mint">
+                      {ep.method}
+                    </span>
+                  </td>
+                  <td className="px-4 py-2.5">
+                    <a href={`#${ep.path.replace(/\//g, "-").slice(1)}`} className="text-accent2 font-[var(--font-mono)] text-[0.7rem] hover:text-accent transition-colors no-underline">
+                      {ep.path}
+                    </a>
+                  </td>
+                  <td className="px-4 py-2.5 text-dim hidden sm:table-cell">
+                    {ep.description.split(".")[0]}.
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      {/* Endpoint Details */}
+      <section className="mb-12 space-y-6">
+        <div className="section-title">ENDPOINT REFERENCE</div>
+        {ENDPOINTS.map((ep) => (
+          <EndpointCard key={ep.path} endpoint={ep} />
+        ))}
+      </section>
+
+      {/* Error Responses */}
+      <section className="mb-12">
+        <div className="section-title">ERROR RESPONSES</div>
+        <div className="cryo-panel p-6 sm:p-8 space-y-4">
+          <p className="text-dim text-sm leading-relaxed">
+            All endpoints return consistent error shapes:
+          </p>
+          <div className="space-y-3">
+            <ErrorExample
+              status={400}
+              description="Invalid query parameter"
+              body='{ "error": "Invalid limit: \\"abc\\" — must be a positive integer" }'
+            />
+            <ErrorExample
+              status={500}
+              description="Database query failed"
+              body='{ "error": "Database query failed", "data": [], "source": "error" }'
+            />
+            <ErrorExample
+              status={503}
+              description="No data available (poller hasn't run)"
+              body='{ "error": "No state data available yet — poller may not have run", "data": null, "source": "empty" }'
+            />
+          </div>
+        </div>
+      </section>
+
+      {/* Rate Limiting */}
+      <section className="mb-12">
+        <div className="section-title">RATE LIMITING &amp; CACHING</div>
+        <div className="cryo-panel p-6 sm:p-8">
+          <p className="text-dim text-sm leading-relaxed mb-3">
+            There are no hard rate limits, but please be respectful. The data updates every 5 minutes —
+            polling faster won&apos;t get you fresher data.
+          </p>
+          <ul className="space-y-1.5 text-xs text-dim/80">
+            <li className="flex gap-2">
+              <span className="text-accent2 shrink-0">▸</span>
+              <span>Responses include <code className="text-accent2 text-[0.65rem]">Cache-Control</code> headers — respect them</span>
+            </li>
+            <li className="flex gap-2">
+              <span className="text-accent2 shrink-0">▸</span>
+              <span>Cloudflare sits in front — aggressive polling may be throttled at the edge</span>
+            </li>
+            <li className="flex gap-2">
+              <span className="text-accent2 shrink-0">▸</span>
+              <span>For bulk historical data, use the <code className="text-accent2 text-[0.65rem]">since</code> param instead of fetching everything</span>
+            </li>
+            <li className="flex gap-2">
+              <span className="text-accent2 shrink-0">▸</span>
+              <span>If you&apos;re building a tool that polls regularly, 5-minute intervals are ideal</span>
+            </li>
+          </ul>
+        </div>
+      </section>
+
+      {/* Bottom nav */}
+      <div className="flex flex-wrap gap-4 justify-center">
+        <Link
+          href="/contribute"
+          className="font-[var(--font-display)] text-xs tracking-[3px] uppercase px-6 py-3 bg-accent/10 border border-accent text-accent hover:bg-accent/20 transition-colors no-underline"
+        >
+          CONTRIBUTE →
+        </Link>
+        <a
+          href={URLS.breacherNetRepo}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="font-[var(--font-display)] text-xs tracking-[3px] uppercase px-6 py-3 bg-panel border border-border text-dim hover:text-foreground hover:border-accent transition-colors no-underline"
+        >
+          SOURCE CODE →
+        </a>
+      </div>
+    </main>
+  );
+}
+
+function EndpointCard({ endpoint }: { endpoint: Endpoint }) {
+  const anchorId = endpoint.path.replace(/\//g, "-").slice(1);
+
+  return (
+    <div id={anchorId} className="cryo-panel p-6 sm:p-8 scroll-mt-24">
+      {/* Header */}
+      <div className="flex items-center gap-3 mb-3 flex-wrap">
+        <span className="font-[var(--font-display)] text-[0.65rem] tracking-[2px] px-2.5 py-1 bg-mint/10 border border-mint/30 text-mint">
+          {endpoint.method}
+        </span>
+        <code className="font-[var(--font-mono)] text-sm text-accent2 break-all">
+          {endpoint.path}
+        </code>
+        {endpoint.cache && (
+          <span className="font-[var(--font-display)] text-[0.55rem] tracking-[1px] px-2 py-0.5 bg-accent/5 border border-border text-dim ml-auto">
+            CACHE: {endpoint.cache}
+          </span>
+        )}
+      </div>
+
+      <p className="text-dim text-sm leading-relaxed mb-4">{endpoint.description}</p>
+
+      {/* Query Parameters */}
+      {endpoint.params && endpoint.params.length > 0 && (
+        <div className="mb-4">
+          <h4 className="font-[var(--font-display)] text-[0.6rem] tracking-[2px] text-dim mb-2">
+            QUERY PARAMETERS
+          </h4>
+          <div className="overflow-x-auto">
+            <table className="w-full text-xs">
+              <thead>
+                <tr className="border-b border-border/50">
+                  <th className="text-left text-dim px-3 py-1.5 font-normal">Name</th>
+                  <th className="text-left text-dim px-3 py-1.5 font-normal">Type</th>
+                  <th className="text-left text-dim px-3 py-1.5 font-normal hidden sm:table-cell">Default</th>
+                  <th className="text-left text-dim px-3 py-1.5 font-normal">Description</th>
+                </tr>
+              </thead>
+              <tbody>
+                {endpoint.params.map((p) => (
+                  <tr key={p.name} className="border-b border-border/20">
+                    <td className="px-3 py-1.5">
+                      <code className="text-accent2 text-[0.65rem]">{p.name}</code>
+                    </td>
+                    <td className="px-3 py-1.5 text-dim/80 font-[var(--font-mono)] text-[0.6rem]">{p.type}</td>
+                    <td className="px-3 py-1.5 text-dim/60 hidden sm:table-cell">{p.default ?? "—"}</td>
+                    <td className="px-3 py-1.5 text-dim/80">{p.description}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+
+      {/* Response Fields */}
+      <div className="mb-4">
+        <h4 className="font-[var(--font-display)] text-[0.6rem] tracking-[2px] text-dim mb-2">
+          RESPONSE FIELDS
+        </h4>
+        <div className="overflow-x-auto">
+          <table className="w-full text-xs">
+            <thead>
+              <tr className="border-b border-border/50">
+                <th className="text-left text-dim px-3 py-1.5 font-normal">Field</th>
+                <th className="text-left text-dim px-3 py-1.5 font-normal">Type</th>
+                <th className="text-left text-dim px-3 py-1.5 font-normal">Description</th>
+              </tr>
+            </thead>
+            <tbody>
+              {endpoint.responseFields.map((f) => (
+                <tr key={f.name} className="border-b border-border/20">
+                  <td className="px-3 py-1.5">
+                    <code className="text-accent2 text-[0.65rem]">{f.name}</code>
+                  </td>
+                  <td className="px-3 py-1.5 text-dim/80 font-[var(--font-mono)] text-[0.6rem] whitespace-nowrap">{f.type}</td>
+                  <td className="px-3 py-1.5 text-dim/80">{f.description}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      {/* Example Response */}
+      <div>
+        <h4 className="font-[var(--font-display)] text-[0.6rem] tracking-[2px] text-dim mb-2">
+          EXAMPLE RESPONSE
+        </h4>
+        <pre className="bg-background/80 border border-border/50 p-4 overflow-x-auto text-[0.7rem] leading-relaxed">
+          <code className="text-dim/80">{endpoint.example}</code>
+        </pre>
+      </div>
+    </div>
+  );
+}
+
+function ErrorExample({
+  status,
+  description,
+  body,
+}: {
+  status: number;
+  description: string;
+  body: string;
+}) {
+  return (
+    <div className="flex items-start gap-3">
+      <span className="font-[var(--font-display)] text-[0.65rem] tracking-[1px] px-2 py-0.5 bg-red-500/10 border border-red-500/30 text-red-400 shrink-0 mt-0.5">
+        {status}
+      </span>
+      <div className="flex-1 min-w-0">
+        <div className="text-foreground text-xs mb-1">{description}</div>
+        <pre className="text-[0.65rem] text-dim/60 overflow-x-auto">
+          <code>{body}</code>
+        </pre>
+      </div>
+    </div>
+  );
+}

--- a/src/app/contribute/page.tsx
+++ b/src/app/contribute/page.tsx
@@ -1,0 +1,310 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { URLS, SITE_URL } from "@/lib/urls";
+
+export const metadata: Metadata = {
+  title: "Contribute",
+  description:
+    "Ways to contribute to Breachers of Tomorrow — ARG research, code, writing, design, community building, and data analysis.",
+  openGraph: {
+    title: "Contribute // BREACHER.NET",
+    description:
+      "Find your path. Every Breacher brings something unique to the team.",
+    url: `${SITE_URL}/contribute`,
+  },
+};
+
+interface ContributionPath {
+  icon: string;
+  title: string;
+  tagline: string;
+  description: string;
+  tasks: string[];
+  cta: { label: string; href: string; external?: boolean };
+}
+
+const PATHS: ContributionPath[] = [
+  {
+    icon: "🔍",
+    title: "ARG RESEARCH",
+    tagline: "Best for: Anyone following the Marathon ARG",
+    description:
+      "Track changes on cryoarchive.systems, document discoveries, share findings, and help organize research into structured wiki pages.",
+    tasks: [
+      "Track sector changes and kill count patterns",
+      "Document discoveries in the Community Doc",
+      "Share findings in Discord #arg-general",
+      "Help structure research into wiki articles",
+    ],
+    cta: { label: "OPEN COMMUNITY DOC", href: URLS.communityDoc, external: true },
+  },
+  {
+    icon: "💻",
+    title: "CODE & TOOLS",
+    tagline: "Best for: Developers, designers, data enthusiasts",
+    description:
+      "Contribute to breacher.net, build data visualizations, improve the poller service, or hack on your own community tools.",
+    tasks: [
+      "Fix bugs or build features — check open issues",
+      "Improve data visualizations and charts",
+      "Help with the Python poller service",
+      "Build analysis tools or browser extensions",
+    ],
+    cta: { label: "VIEW OPEN ISSUES", href: `${URLS.breacherNetRepo}/issues`, external: true },
+  },
+  {
+    icon: "📝",
+    title: "WRITING & DOCS",
+    tagline: "Best for: Writers, editors, organizers",
+    description:
+      "Migrate research from the Google Doc to structured wiki pages, write guides for new members, and document ARG theories with evidence.",
+    tasks: [
+      "Help migrate research to wiki pages",
+      "Write onboarding guides for new members",
+      "Document theories with supporting evidence",
+      "Improve existing documentation and README files",
+    ],
+    cta: { label: "OPEN WIKI", href: URLS.wiki, external: true },
+  },
+  {
+    icon: "🎨",
+    title: "DESIGN & BRANDING",
+    tagline: "Best for: Designers, artists, creative types",
+    description:
+      "Help develop the community's visual identity — social graphics, Discord assets, event banners, and brand guide contributions.",
+    tasks: [
+      "Create social media graphics and banners",
+      "Design Discord server assets and emotes",
+      "Contribute to the community brand guide",
+      "Design infographics for ARG data",
+    ],
+    cta: { label: "VIEW BRAND GUIDE", href: `${URLS.github}/community/blob/main/branding/BRAND-GUIDE.md`, external: true },
+  },
+  {
+    icon: "🎙️",
+    title: "COMMUNITY",
+    tagline: "Best for: Social people, event organizers, moderators",
+    description:
+      "Welcome new members, organize community events, moderate discussions, and help share community content on social media.",
+    tasks: [
+      "Welcome and guide new members in Discord",
+      "Organize events — raid nights, solving sessions",
+      "Help moderate discussions",
+      "Share community content on social platforms",
+    ],
+    cta: { label: "JOIN DISCORD", href: URLS.discord, external: true },
+  },
+  {
+    icon: "📊",
+    title: "DATA & ANALYSIS",
+    tagline: "Best for: Data enthusiasts, spreadsheet warriors",
+    description:
+      "Track sector data, kill counts, and stabilization patterns. Build charts, validate theories with evidence, and maintain community datasets.",
+    tasks: [
+      "Track sector states and stabilization patterns",
+      "Create charts and data visualizations",
+      "Validate theories with quantitative evidence",
+      "Maintain community tracking spreadsheets",
+    ],
+    cta: { label: "VIEW DASHBOARD", href: "/cryoarchive" },
+  },
+];
+
+export default function ContributePage() {
+  return (
+    <main className="max-w-5xl mx-auto px-4 sm:px-8 py-8 sm:py-16">
+      {/* Hero */}
+      <div className="text-center mb-12">
+        <h1 className="font-[var(--font-display)] text-2xl sm:text-4xl font-black text-accent glow-accent tracking-[6px] mb-4">
+          CONTRIBUTE
+        </h1>
+        <p className="text-dim text-sm sm:text-base tracking-[2px] max-w-2xl mx-auto mb-2">
+          FIND YOUR PATH — EVERY BREACHER BRINGS SOMETHING UNIQUE
+        </p>
+        <p className="text-dim/60 text-xs tracking-[1px] max-w-xl mx-auto">
+          No contribution is too small. Every data point tracked, every question answered,
+          and every discovery shared makes the community stronger.
+        </p>
+      </div>
+
+      {/* Contribution Paths */}
+      <section className="mb-12">
+        <div className="section-title">CONTRIBUTION PATHS</div>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          {PATHS.map((path) => (
+            <PathCard key={path.title} path={path} />
+          ))}
+        </div>
+      </section>
+
+      {/* Getting Started */}
+      <section className="mb-12">
+        <div className="section-title">GETTING STARTED</div>
+        <div className="cryo-panel p-6 sm:p-8">
+          <ol className="space-y-4 text-sm">
+            <li className="flex gap-3">
+              <span className="font-[var(--font-display)] text-accent text-xs tracking-[2px] shrink-0 mt-0.5">01</span>
+              <div>
+                <div className="text-foreground font-medium mb-0.5">Pick what interests you</div>
+                <p className="text-dim text-xs leading-relaxed">
+                  Browse the paths above — research, code, writing, design, community, or data.
+                  You can always switch later.
+                </p>
+              </div>
+            </li>
+            <li className="flex gap-3">
+              <span className="font-[var(--font-display)] text-accent text-xs tracking-[2px] shrink-0 mt-0.5">02</span>
+              <div>
+                <div className="text-foreground font-medium mb-0.5">Join the right channels</div>
+                <p className="text-dim text-xs leading-relaxed">
+                  <code className="text-accent2 text-[0.65rem]">#arg-general</code> for research,{" "}
+                  <code className="text-accent2 text-[0.65rem]">#coders</code> for dev work,{" "}
+                  <code className="text-accent2 text-[0.65rem]">#breacher-net</code> for general chat.
+                </p>
+              </div>
+            </li>
+            <li className="flex gap-3">
+              <span className="font-[var(--font-display)] text-accent text-xs tracking-[2px] shrink-0 mt-0.5">03</span>
+              <div>
+                <div className="text-foreground font-medium mb-0.5">Start small</div>
+                <p className="text-dim text-xs leading-relaxed">
+                  Fix a typo, add a data point, answer a question, share a discovery.
+                  Small actions compound.
+                </p>
+              </div>
+            </li>
+            <li className="flex gap-3">
+              <span className="font-[var(--font-display)] text-accent text-xs tracking-[2px] shrink-0 mt-0.5">04</span>
+              <div>
+                <div className="text-foreground font-medium mb-0.5">Ask for help</div>
+                <p className="text-dim text-xs leading-relaxed">
+                  The Keepers and community are here to support you. No question is too basic.
+                </p>
+              </div>
+            </li>
+          </ol>
+        </div>
+      </section>
+
+      {/* Tech Stack (for developers) */}
+      <section className="mb-12">
+        <div className="section-title">FOR DEVELOPERS</div>
+        <div className="cryo-panel p-6 sm:p-8">
+          <p className="text-dim text-sm leading-relaxed mb-4">
+            breacher.net is fully open source. Here&apos;s the stack:
+          </p>
+          <div className="grid grid-cols-2 sm:grid-cols-3 gap-3 mb-6">
+            {[
+              { label: "Framework", value: "Next.js 16" },
+              { label: "UI", value: "React 19" },
+              { label: "Language", value: "TypeScript 5" },
+              { label: "Styling", value: "Tailwind CSS 4" },
+              { label: "Database", value: "PostgreSQL" },
+              { label: "Poller", value: "Python" },
+            ].map((item) => (
+              <div key={item.label} className="bg-background/50 border border-border/50 px-3 py-2">
+                <div className="font-[var(--font-display)] text-[0.55rem] tracking-[2px] text-dim mb-0.5">
+                  {item.label.toUpperCase()}
+                </div>
+                <div className="text-accent2 text-xs">{item.value}</div>
+              </div>
+            ))}
+          </div>
+          <div className="flex flex-wrap gap-4">
+            <a
+              href={URLS.breacherNetRepo}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-[var(--font-display)] text-[0.6rem] tracking-[2px] uppercase px-4 py-2.5 bg-accent/10 border border-accent text-accent hover:bg-accent/20 transition-colors no-underline inline-flex items-center gap-2"
+            >
+              <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path
+                  fillRule="evenodd"
+                  d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"
+                  clipRule="evenodd"
+                />
+              </svg>
+              VIEW SOURCE
+            </a>
+            <a
+              href={`${URLS.breacherNetRepo}/issues`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-[var(--font-display)] text-[0.6rem] tracking-[2px] uppercase px-4 py-2.5 bg-panel border border-border text-dim hover:text-foreground hover:border-accent transition-colors no-underline"
+            >
+              OPEN ISSUES
+            </a>
+            <Link
+              href="/api-docs"
+              className="font-[var(--font-display)] text-[0.6rem] tracking-[2px] uppercase px-4 py-2.5 bg-panel border border-border text-dim hover:text-foreground hover:border-accent transition-colors no-underline"
+            >
+              API DOCS
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      {/* Bottom nav */}
+      <div className="flex flex-wrap gap-4 justify-center">
+        <Link
+          href="/community"
+          className="font-[var(--font-display)] text-xs tracking-[3px] uppercase px-6 py-3 bg-accent/10 border border-accent text-accent hover:bg-accent/20 transition-colors no-underline"
+        >
+          COMMUNITY →
+        </Link>
+        <Link
+          href="/"
+          className="font-[var(--font-display)] text-xs tracking-[3px] uppercase px-6 py-3 bg-panel border border-border text-dim hover:text-foreground hover:border-accent transition-colors no-underline"
+        >
+          HOME →
+        </Link>
+      </div>
+    </main>
+  );
+}
+
+function PathCard({ path }: { path: ContributionPath }) {
+  const isInternal = !path.cta.external;
+  const LinkComponent = isInternal ? Link : "a";
+  const externalProps = isInternal
+    ? {}
+    : { target: "_blank", rel: "noopener noreferrer" };
+
+  return (
+    <div className="cryo-panel p-6 flex flex-col">
+      <div className="flex items-start gap-3 mb-3">
+        <span className="text-2xl shrink-0" aria-hidden="true">
+          {path.icon}
+        </span>
+        <div>
+          <h3 className="font-[var(--font-display)] text-xs tracking-[3px] text-accent mb-1">
+            {path.title}
+          </h3>
+          <p className="text-dim/60 text-[0.65rem] italic">{path.tagline}</p>
+        </div>
+      </div>
+      <p className="text-dim text-sm leading-relaxed mb-3">{path.description}</p>
+      <ul className="space-y-1.5 mb-4 flex-1">
+        {path.tasks.map((task) => (
+          <li key={task} className="flex gap-2 text-xs text-dim/80">
+            <span className="text-accent2 shrink-0 mt-0.5">▸</span>
+            {task}
+          </li>
+        ))}
+      </ul>
+      <LinkComponent
+        href={path.cta.href}
+        {...externalProps}
+        className="font-[var(--font-display)] text-[0.6rem] tracking-[2px] uppercase px-4 py-2.5 bg-accent/10 border border-accent/50 text-accent hover:bg-accent/20 hover:border-accent transition-colors no-underline text-center inline-flex items-center justify-center gap-2"
+      >
+        {path.cta.label}
+        {path.cta.external && (
+          <svg className="w-2.5 h-2.5 opacity-60" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+          </svg>
+        )}
+        {!path.cta.external && " →"}
+      </LinkComponent>
+    </div>
+  );
+}

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -32,6 +32,8 @@ const NAV_SECTIONS: NavSection[] = [
     links: [
       { href: "/about", label: "About" },
       { href: "/community", label: "Community" },
+      { href: "/contribute", label: "Contribute" },
+      { href: "/api-docs", label: "API Docs" },
       { href: URLS.wiki, label: "Wiki", external: true },
       { href: URLS.discord, label: "Discord", external: true },
       {


### PR DESCRIPTION
## Summary

Adds two new pages to breacher.net — **Contribute** and **API Documentation**.

### `/contribute` (closes #60)

Card-based layout with 6 contribution paths sourced from [community/onboarding/CONTRIBUTION-PATHS.md](https://github.com/breachers-of-tomorrow/community/blob/main/onboarding/CONTRIBUTION-PATHS.md):

- 🔍 **ARG Research** — Track changes, document discoveries, share in Discord
- 💻 **Code & Tools** — Open issues, poller, visualizations, browser extensions
- 📝 **Writing & Docs** — Wiki migration, onboarding guides, theory documentation
- 🎨 **Design & Branding** — Social graphics, Discord assets, brand guide
- 🎙️ **Community** — Welcoming, events, moderation, social sharing
- 📊 **Data & Analysis** — Sector tracking, charts, theory validation

Each card has: icon, tagline, description, task bullets, and a CTA button linking to the relevant resource.

Also includes:
- **Getting Started** section (4 numbered steps)
- **For Developers** section with tech stack grid and links to source/issues/API docs

### `/api-docs` (closes #45)

Full REST API reference documenting all 8 endpoints:

| Endpoint | Description |
|----------|-------------|
| `GET /api/health` | Health check for monitoring |
| `GET /api/state/latest` | Latest cryoarchive state snapshot |
| `GET /api/state/history` | Historical state snapshots |
| `GET /api/stabilization/latest` | Latest camera stabilization |
| `GET /api/stabilization/history` | Historical stabilization data |
| `GET /api/builds/latest` | Most recent build event |
| `GET /api/builds` | Build change event list |
| `GET /api/index-entries` | Index entries with stats (1,200+) |

Each endpoint documented with:
- Method badge + path
- Description
- Query parameters (name, type, default, description)
- Response fields table
- Example JSON response
- Cache-Control info

Also includes:
- **Quick Reference** table with anchor links
- **Error Responses** section (400, 500, 503 examples)
- **Rate Limiting & Caching** guidance

### Navigation

Added both pages to the **BREACHER.NET** nav section between Community and Wiki.

### Build

✅ `next build` passes — both routes render as static pages.