### PR TITLE
Refactor: Simplify average KPM to Flat Average

### DIFF
--- a/src/components/KillCountEta.tsx
+++ b/src/components/KillCountEta.tsx
@@ -27,7 +27,7 @@ interface Projection {
   eta: Date;
   /** Kills remaining to target */
   remaining: number;
-  /** Current KPM (last ~45 min average) */
+  /** Current KPM (last ~30 min average) */
   currentKpm: number;
   /** Average KPM across all history */
   avgKpm: number;


### PR DESCRIPTION
Changes average KPM to a simple flat average calculation

There are more changes I'd recommend we do here (for instance the currentKPM calculation), but those should be done in a different PR imo. 

The PR simply calculates the average KPM by taking the timestamp of the first datapoint, the last datapoint and the total kill count.