### PR TITLE
feat: Restructure navigation for community pivot

### DIFF
--- a/src/app/marathon/page.tsx
+++ b/src/app/marathon/page.tsx
@@ -1,0 +1,60 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { URLS, SITE_URL } from "@/lib/urls";
+
+export const metadata: Metadata = {
+  title: "Marathon Metrics",
+  description:
+    "Marathon game metrics — kill counts, player data, weapon stats, and community analytics from The Breacher Network.",
+  openGraph: {
+    title: "Marathon Metrics // BREACHER.NET",
+    description:
+      "Marathon game metrics — kill counts, player data, weapon stats, and community analytics.",
+    url: `${SITE_URL}/marathon`,
+  },
+};
+
+export default function MarathonPage() {
+  return (
+    <main className="max-w-4xl mx-auto px-4 sm:px-8 py-8 sm:py-16">
+      {/* Hero */}
+      <div className="text-center mb-12">
+        <h1 className="font-[var(--font-display)] text-2xl sm:text-4xl font-black text-accent glow-accent tracking-[6px] mb-4">
+          MARATHON METRICS
+        </h1>
+        <p className="text-dim text-sm sm:text-base tracking-[2px] max-w-2xl mx-auto">
+          GAME DATA, ANALYTICS, AND COMMUNITY TOOLS
+        </p>
+      </div>
+
+      {/* Coming soon notice */}
+      <div className="cryo-panel p-8 text-center mb-8">
+        <div className="absolute top-0 left-0 right-0 h-0.5 bg-gradient-to-r from-accent via-accent2 to-accent" />
+        <div className="font-[var(--font-display)] text-xs tracking-[4px] text-accent2 mb-4">
+          COMING SOON
+        </div>
+        <p className="text-text-body text-sm leading-relaxed max-w-lg mx-auto mb-6">
+          Marathon metrics are being relocated from the Cryoarchive dashboard to
+          their own dedicated page. Kill counts, player data, analytics, and
+          projections will live here.
+        </p>
+        <div className="flex items-center justify-center gap-4 flex-wrap">
+          <Link
+            href="/cryoarchive"
+            className="font-[var(--font-display)] text-xs tracking-[2px] px-4 py-2 border border-accent text-accent hover:bg-accent/10 transition-colors no-underline"
+          >
+            VIEW CRYOARCHIVE DASHBOARD →
+          </Link>
+          <a
+            href={URLS.weaponsDb}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-[var(--font-display)] text-xs tracking-[2px] px-4 py-2 border border-accent2 text-accent2 hover:bg-accent2/10 transition-colors no-underline"
+          >
+            WEAPONS DATABASE ↗
+          </a>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -54,5 +54,11 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: "monthly",
       priority: 0.6,
     },
+    {
+      url: `${baseUrl}/marathon`,
+      lastModified: now,
+      changeFrequency: "daily",
+      priority: 0.8,
+    },
   ];
 }

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -18,6 +18,23 @@ interface NavSection {
 
 const NAV_SECTIONS: NavSection[] = [
   {
+    label: "BREACHER NET",
+    links: [
+      { href: "/about", label: "About" },
+      { href: "/community", label: "Community" },
+      { href: "/contribute", label: "Contribute" },
+      { href: URLS.wiki, label: "Wiki", external: true },
+      { href: URLS.discord, label: "Discord", external: true },
+    ],
+  },
+  {
+    label: "MARATHON",
+    links: [
+      { href: "/marathon", label: "Metrics" },
+      { href: URLS.weaponsDb, label: "Weapons DB", external: true },
+    ],
+  },
+  {
     label: "CRYOARCHIVE",
     links: [
       { href: "/cryoarchive", label: "Dashboard" },
@@ -28,25 +45,15 @@ const NAV_SECTIONS: NavSection[] = [
     ],
   },
   {
-    label: "BREACHER.NET",
+    label: "RESOURCES",
     links: [
-      { href: "/about", label: "About" },
-      { href: "/community", label: "Community" },
-      { href: "/contribute", label: "Contribute" },
       { href: "/api-docs", label: "API Docs" },
       { href: "/status", label: "Status" },
-      { href: URLS.wiki, label: "Wiki", external: true },
-      { href: URLS.discord, label: "Discord", external: true },
       {
         href: URLS.communityDoc,
         label: "Community Doc",
         external: true,
       },
-    ],
-  },
-  {
-    label: "MARATHON",
-    links: [
       { href: URLS.winnower, label: "Winnower", external: true },
       { href: URLS.tauCeti, label: "Tau Ceti", external: true },
     ],


### PR DESCRIPTION
## Summary

Reorganizes the site navigation for the community pivot from ARG-focused Cryoarchive tracker to "The Breacher Network" community hub.

## Navigation Changes

### Before (3 sections)
```
CRYOARCHIVE → BREACHER.NET → MARATHON
```

### After (4 sections)
```
BREACHER NET → MARATHON → CRYOARCHIVE → RESOURCES
```

| Section | Links |
|---------|-------|
| **BREACHER NET** | About, Community, Contribute, Wiki↗, Discord↗ |
| **MARATHON** | Metrics (`/marathon`), Weapons DB↗ (`arms-dealer.breacher.net`) |
| **CRYOARCHIVE** | Dashboard, Cameras, Maps, Index, Changes *(unchanged)* |
| **RESOURCES** | API Docs, Status, Community Doc↗, Winnower↗, Tau Ceti↗ |

## Key decisions

- **Weapons DB elevated** — Now first-class in MARATHON section (was absent from nav; URL was already in `urls.ts`)
- **RESOURCES section** — Groups utility/reference links that were scattered across BREACHER.NET and MARATHON
- **BREACHER NET (no dot)** — Section label uses space, not period, for cleaner display
- **All existing URLs preserved** — No routes removed, no links broken

## New route: `/marathon`

Added a placeholder page at `/marathon` with "coming soon" messaging and links to the cryoarchive dashboard and weapons DB. The full metrics page will be built in #79 (depends on hooks from #76).

Sitemap updated with the new route.

## Validation

```
✅ npm run lint   — clean
✅ npm run test   — 73/73 passed
✅ npm run build  — production build succeeds, /marathon renders as static page
```

Closes #77
Part of #75