### PR TITLE
feat: Build /marathon metrics page with relocated charts (#79)

### DIFF
--- a/src/app/cryoarchive/DashboardClient.tsx
+++ b/src/app/cryoarchive/DashboardClient.tsx
@@ -11,66 +11,8 @@ import {
 } from "@/lib/format";
 import { SECTOR_NAMES } from "@/lib/types";
 import type { SectorName } from "@/lib/types";
-import dynamic from "next/dynamic";
+import Link from "next/link";
 import { URLS } from "@/lib/urls";
-import type { RangeLabel } from "@/lib/chart-utils";
-
-const KillCountChart = dynamic(
-  () => import("@/components/KillCountChart").then((m) => m.KillCountChart),
-  {
-    loading: () => (
-      <div className="cryo-panel p-5 h-[300px] flex items-center justify-center">
-        <div className="font-[var(--font-display)] text-xs tracking-[4px] text-dim animate-blink">
-          LOADING CHART...
-        </div>
-      </div>
-    ),
-    ssr: false,
-  },
-);
-
-const KillCountEta = dynamic(
-  () => import("@/components/KillCountEta").then((m) => m.KillCountEta),
-  {
-    loading: () => (
-      <div className="cryo-panel p-5 mb-8 h-[100px] flex items-center justify-center">
-        <div className="font-[var(--font-display)] text-xs tracking-[4px] text-dim animate-blink">
-          CALCULATING PROJECTION...
-        </div>
-      </div>
-    ),
-    ssr: false,
-  },
-);
-
-const PlayerCountChart = dynamic(
-  () =>
-    import("@/components/PlayerCountChart").then((m) => m.PlayerCountChart),
-  {
-    loading: () => (
-      <div className="cryo-panel p-5 h-[260px] flex items-center justify-center">
-        <div className="font-[var(--font-display)] text-xs tracking-[4px] text-dim animate-blink">
-          LOADING PLAYER DATA...
-        </div>
-      </div>
-    ),
-    ssr: false,
-  },
-);
-
-const KillAnalytics = dynamic(
-  () => import("@/components/KillAnalytics").then((m) => m.KillAnalytics),
-  {
-    loading: () => (
-      <div className="cryo-panel p-5 h-[120px] flex items-center justify-center">
-        <div className="font-[var(--font-display)] text-xs tracking-[4px] text-dim animate-blink">
-          COMPUTING ANALYTICS...
-        </div>
-      </div>
-    ),
-    ssr: false,
-  },
-);
 
 interface DashboardData {
   killCount: number;
@@ -100,9 +42,6 @@ export function DashboardClient({ initialData }: Props) {
   // Ref to track current data without triggering fetchLatest recreation
   const dataRef = useRef(data);
   dataRef.current = data;
-
-  // Shared chart time range — syncs kill chart and player chart
-  const [chartRange, setChartRange] = useState<RangeLabel>("24H");
 
   // Ticking state
   const [, setTick] = useState(0);
@@ -256,9 +195,12 @@ export function DashboardClient({ initialData }: Props) {
         <StateFlag label="MEMORY COMPLETED" value={data.memoryCompleted} />
       </div>
 
-      {/* KILL COUNT */}
+      {/* KILL COUNT — summary with link to full metrics */}
       <div className="section-title">UESC KILL COUNT</div>
-      <div className="cryo-panel p-6 mb-8 flex items-center gap-8 flex-wrap" aria-live="polite" aria-atomic="true">
+      <Link
+        href="/marathon"
+        className="block cryo-panel p-6 mb-8 flex items-center gap-8 flex-wrap hover:border-accent/30 transition-colors no-underline group"
+      >
         <div className="absolute top-0 left-0 right-0 h-0.5 bg-gradient-to-r from-danger to-transparent" />
         <div>
           <div className="font-[var(--font-display)] text-[0.65rem] tracking-[3px] text-dim">
@@ -284,33 +226,16 @@ export function DashboardClient({ initialData }: Props) {
           </div>
         )}
         <div className="ml-auto text-right">
-          {nextUpdate && (
-            <div className="text-[0.7rem] text-dim">
-              NEXT UPDATE: {toLocalTimeOnly(nextUpdate)}
-            </div>
-          )}
+          <div className="font-[var(--font-display)] text-xs tracking-[2px] text-accent group-hover:text-accent2 transition-colors">
+            VIEW FULL METRICS →
+          </div>
           {lastFetch && (
             <div className="text-[0.65rem] text-dim mt-1">
               Updated {timeAgo(lastFetch)}
             </div>
           )}
         </div>
-      </div>
-
-      {/* ETA TO 500M */}
-      <KillCountEta currentKills={data.killCount} />
-
-      {/* Kill Count Chart */}
-      <div className="section-title">KILL COUNT OVER TIME</div>
-      <KillCountChart range={chartRange} onRangeChange={setChartRange} />
-
-      {/* Player Count Chart (synced time range) */}
-      <div className="section-title mt-8">STEAM PLAYERS OVER TIME</div>
-      <PlayerCountChart range={chartRange} onRangeChange={setChartRange} />
-
-      {/* Kill Analytics */}
-      <div className="section-title mt-8">KILL ANALYTICS</div>
-      <KillAnalytics />
+      </Link>
 
       {/* SHIP DATE */}
       <div className="cryo-panel p-5 mt-8">

--- a/src/app/marathon/MarathonClient.tsx
+++ b/src/app/marathon/MarathonClient.tsx
@@ -1,0 +1,192 @@
+"use client";
+
+import { useState } from "react";
+import dynamic from "next/dynamic";
+import { formatNumber, timeAgo } from "@/lib/format";
+import { URLS } from "@/lib/urls";
+import type { RangeLabel } from "@/lib/chart-utils";
+
+/* ------------------------------------------------------------------ */
+/*  Lazy-loaded chart components (client-only, no SSR)                 */
+/* ------------------------------------------------------------------ */
+
+const KillCountChart = dynamic(
+  () => import("@/components/KillCountChart").then((m) => m.KillCountChart),
+  {
+    loading: () => (
+      <div className="cryo-panel p-5 h-[300px] flex items-center justify-center">
+        <div className="font-[var(--font-display)] text-xs tracking-[4px] text-dim animate-blink">
+          LOADING CHART...
+        </div>
+      </div>
+    ),
+    ssr: false,
+  },
+);
+
+const KillCountEta = dynamic(
+  () => import("@/components/KillCountEta").then((m) => m.KillCountEta),
+  {
+    loading: () => (
+      <div className="cryo-panel p-5 mb-8 h-[100px] flex items-center justify-center">
+        <div className="font-[var(--font-display)] text-xs tracking-[4px] text-dim animate-blink">
+          CALCULATING PROJECTION...
+        </div>
+      </div>
+    ),
+    ssr: false,
+  },
+);
+
+const PlayerCountChart = dynamic(
+  () =>
+    import("@/components/PlayerCountChart").then((m) => m.PlayerCountChart),
+  {
+    loading: () => (
+      <div className="cryo-panel p-5 h-[260px] flex items-center justify-center">
+        <div className="font-[var(--font-display)] text-xs tracking-[4px] text-dim animate-blink">
+          LOADING PLAYER DATA...
+        </div>
+      </div>
+    ),
+    ssr: false,
+  },
+);
+
+const KillAnalytics = dynamic(
+  () => import("@/components/KillAnalytics").then((m) => m.KillAnalytics),
+  {
+    loading: () => (
+      <div className="cryo-panel p-5 h-[120px] flex items-center justify-center">
+        <div className="font-[var(--font-display)] text-xs tracking-[4px] text-dim animate-blink">
+          COMPUTING ANALYTICS...
+        </div>
+      </div>
+    ),
+    ssr: false,
+  },
+);
+
+/* ------------------------------------------------------------------ */
+/*  Props                                                              */
+/* ------------------------------------------------------------------ */
+
+interface Props {
+  initialKillCount: number | null;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Component                                                          */
+/* ------------------------------------------------------------------ */
+
+const STATE_API = "/api/state/latest";
+
+export function MarathonClient({ initialKillCount }: Props) {
+  const [killCount, setKillCount] = useState<number | null>(initialKillCount);
+  const [lastFetch, setLastFetch] = useState<Date | null>(
+    initialKillCount !== null ? new Date() : null,
+  );
+
+  // Shared chart time range — syncs kill chart and player chart
+  const [chartRange, setChartRange] = useState<RangeLabel>("24H");
+
+  // Refresh kill count from API (lightweight — just the latest state)
+  const refreshKillCount = async () => {
+    try {
+      const res = await fetch(`${STATE_API}?t=${Date.now()}`, {
+        cache: "no-store",
+      });
+      if (!res.ok) return;
+      const json = await res.json();
+      const kc = json?.data?.killCount;
+      if (typeof kc === "number") {
+        setKillCount(kc);
+        setLastFetch(new Date());
+      }
+    } catch {
+      // Silently fail — charts have their own data sources
+    }
+  };
+
+  return (
+    <div>
+      {/* Hero */}
+      <div className="text-center mb-10">
+        <h1 className="font-[var(--font-display)] text-2xl sm:text-4xl font-black text-accent glow-accent tracking-[6px] mb-3">
+          MARATHON METRICS
+        </h1>
+        <p className="text-dim text-sm sm:text-base tracking-[2px] max-w-2xl mx-auto">
+          KILL COUNTS, PLAYER DATA, ANALYTICS, AND PROJECTIONS
+        </p>
+      </div>
+
+      {/* Quick links */}
+      <div className="flex items-center justify-center gap-4 flex-wrap mb-10">
+        <a
+          href={URLS.weaponsDb}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="font-[var(--font-display)] text-[0.65rem] tracking-[2px] px-4 py-2 border border-accent2 text-accent2 hover:bg-accent2/10 transition-colors no-underline"
+        >
+          WEAPONS DATABASE ↗
+        </a>
+        <a
+          href={URLS.cryoarchive}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="font-[var(--font-display)] text-[0.65rem] tracking-[2px] px-4 py-2 border border-border text-dim hover:border-accent hover:text-accent transition-colors no-underline"
+        >
+          CRYOARCHIVE.SYSTEMS ↗
+        </a>
+      </div>
+
+      {/* KILL COUNT HERO STAT */}
+      <div className="section-title">UESC KILL COUNT</div>
+      <div
+        className="cryo-panel p-6 mb-8 flex items-center gap-8 flex-wrap cursor-pointer hover:border-accent/30 transition-colors"
+        onClick={refreshKillCount}
+        role="button"
+        tabIndex={0}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") refreshKillCount();
+        }}
+        aria-label="Click to refresh kill count"
+      >
+        <div className="absolute top-0 left-0 right-0 h-0.5 bg-gradient-to-r from-danger to-transparent" />
+        <div>
+          <div className="font-[var(--font-display)] text-[0.65rem] tracking-[3px] text-dim">
+            TOTAL KILLS
+          </div>
+          <div className="font-[var(--font-display)] text-4xl font-black text-danger glow-danger tracking-wider mt-1">
+            {killCount !== null ? formatNumber(killCount) : "—"}
+          </div>
+        </div>
+        <div className="ml-auto text-right">
+          {lastFetch && (
+            <div className="text-[0.65rem] text-dim">
+              Updated {timeAgo(lastFetch)}
+            </div>
+          )}
+          <div className="text-[0.55rem] text-dim mt-1">
+            Click to refresh
+          </div>
+        </div>
+      </div>
+
+      {/* ETA TO 500M */}
+      <KillCountEta currentKills={killCount ?? 0} />
+
+      {/* Kill Count Chart */}
+      <div className="section-title">KILL COUNT OVER TIME</div>
+      <KillCountChart range={chartRange} onRangeChange={setChartRange} />
+
+      {/* Player Count Chart (synced time range) */}
+      <div className="section-title mt-8">STEAM PLAYERS OVER TIME</div>
+      <PlayerCountChart range={chartRange} onRangeChange={setChartRange} />
+
+      {/* Kill Analytics */}
+      <div className="section-title mt-8">KILL ANALYTICS</div>
+      <KillAnalytics />
+    </div>
+  );
+}

--- a/src/app/marathon/error.tsx
+++ b/src/app/marathon/error.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useEffect } from "react";
+import Link from "next/link";
+
+export default function MarathonError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error("Marathon metrics error:", error);
+  }, [error]);
+
+  return (
+    <main className="max-w-3xl mx-auto px-4 sm:px-8 py-16 text-center">
+      <div className="cryo-panel p-8 sm:p-12">
+        <div className="font-[var(--font-display)] text-[0.6rem] tracking-[4px] text-warn mb-4 animate-pulse-slow">
+          ⚠ DATA FEED INTERRUPTED
+        </div>
+        <h1 className="font-[var(--font-display)] text-xl sm:text-2xl font-black text-warn glow-warn tracking-[4px] mb-4">
+          METRICS OFFLINE
+        </h1>
+        <p className="text-dim text-sm mb-8 max-w-md mx-auto">
+          Failed to retrieve metrics data from the database. The poller may be
+          syncing or the database connection was interrupted.
+        </p>
+        {error.digest && (
+          <div className="text-[0.6rem] text-dim mb-6">
+            Error ID: {error.digest}
+          </div>
+        )}
+        <div className="flex items-center justify-center gap-4 flex-wrap">
+          <button
+            onClick={reset}
+            className="font-[var(--font-display)] text-xs tracking-[2px] px-5 py-2.5 border border-accent text-accent hover:bg-accent/10 transition-colors cursor-pointer"
+          >
+            RETRY CONNECTION
+          </button>
+          <Link
+            href="/"
+            className="font-[var(--font-display)] text-xs tracking-[2px] px-5 py-2.5 border border-border text-dim hover:border-accent hover:text-accent transition-colors no-underline"
+          >
+            RETURN TO BASE
+          </Link>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/marathon/loading.tsx
+++ b/src/app/marathon/loading.tsx
@@ -1,0 +1,43 @@
+export default function MarathonLoading() {
+  return (
+    <main className="px-4 sm:px-8 max-w-[1200px] mx-auto py-8 sm:py-16 animate-pulse">
+      {/* Hero skeleton */}
+      <div className="text-center mb-10">
+        <div className="h-8 w-64 bg-border rounded mx-auto mb-3" />
+        <div className="h-4 w-80 bg-border rounded mx-auto" />
+      </div>
+
+      {/* Quick links skeleton */}
+      <div className="flex justify-center gap-4 mb-10">
+        <div className="h-9 w-40 bg-border rounded" />
+        <div className="h-9 w-44 bg-border rounded" />
+      </div>
+
+      {/* Kill count hero skeleton */}
+      <div className="h-3 w-28 bg-border mb-4 rounded" />
+      <div className="cryo-panel p-6 mb-8 flex items-center gap-8">
+        <div>
+          <div className="h-3 w-20 bg-border mb-2 rounded" />
+          <div className="h-10 w-48 bg-border rounded" />
+        </div>
+        <div className="ml-auto text-right">
+          <div className="h-3 w-24 bg-border rounded" />
+        </div>
+      </div>
+
+      {/* ETA skeleton */}
+      <div className="cryo-panel p-5 mb-8 h-[140px]" />
+
+      {/* Chart skeletons */}
+      <div className="h-3 w-36 bg-border mb-4 rounded" />
+      <div className="cryo-panel p-5 h-[300px] mb-8" />
+
+      <div className="h-3 w-40 bg-border mb-4 rounded" />
+      <div className="cryo-panel p-5 h-[260px] mb-8" />
+
+      {/* Analytics skeleton */}
+      <div className="h-3 w-28 bg-border mb-4 rounded" />
+      <div className="cryo-panel p-5 h-[120px]" />
+    </main>
+  );
+}

--- a/src/app/marathon/page.tsx
+++ b/src/app/marathon/page.tsx
@@ -1,11 +1,12 @@
 import type { Metadata } from "next";
-import Link from "next/link";
-import { URLS, SITE_URL } from "@/lib/urls";
+import { fetchState } from "@/lib/api";
+import { SITE_URL } from "@/lib/urls";
+import { MarathonClient } from "./MarathonClient";
 
 export const metadata: Metadata = {
   title: "Marathon Metrics",
   description:
-    "Marathon game metrics — kill counts, player data, weapon stats, and community analytics from The Breacher Network.",
+    "Marathon game metrics — kill counts, player data, weapon stats, kill rate analytics, and 500M ETA projection from The Breacher Network.",
   openGraph: {
     title: "Marathon Metrics // BREACHER.NET",
     description:
@@ -14,47 +15,17 @@ export const metadata: Metadata = {
   },
 };
 
-export default function MarathonPage() {
-  return (
-    <main className="max-w-4xl mx-auto px-4 sm:px-8 py-8 sm:py-16">
-      {/* Hero */}
-      <div className="text-center mb-12">
-        <h1 className="font-[var(--font-display)] text-2xl sm:text-4xl font-black text-accent glow-accent tracking-[6px] mb-4">
-          MARATHON METRICS
-        </h1>
-        <p className="text-dim text-sm sm:text-base tracking-[2px] max-w-2xl mx-auto">
-          GAME DATA, ANALYTICS, AND COMMUNITY TOOLS
-        </p>
-      </div>
+export const revalidate = 0; // Always fresh
 
-      {/* Coming soon notice */}
-      <div className="cryo-panel p-8 text-center mb-8">
-        <div className="absolute top-0 left-0 right-0 h-0.5 bg-gradient-to-r from-accent via-accent2 to-accent" />
-        <div className="font-[var(--font-display)] text-xs tracking-[4px] text-accent2 mb-4">
-          COMING SOON
-        </div>
-        <p className="text-text-body text-sm leading-relaxed max-w-lg mx-auto mb-6">
-          Marathon metrics are being relocated from the Cryoarchive dashboard to
-          their own dedicated page. Kill counts, player data, analytics, and
-          projections will live here.
-        </p>
-        <div className="flex items-center justify-center gap-4 flex-wrap">
-          <Link
-            href="/cryoarchive"
-            className="font-[var(--font-display)] text-xs tracking-[2px] px-4 py-2 border border-accent text-accent hover:bg-accent/10 transition-colors no-underline"
-          >
-            VIEW CRYOARCHIVE DASHBOARD →
-          </Link>
-          <a
-            href={URLS.weaponsDb}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="font-[var(--font-display)] text-xs tracking-[2px] px-4 py-2 border border-accent2 text-accent2 hover:bg-accent2/10 transition-colors no-underline"
-          >
-            WEAPONS DATABASE ↗
-          </a>
-        </div>
-      </div>
+export default async function MarathonPage() {
+  const state = await fetchState();
+
+  // Pass initial kill count for SSR hydration
+  const initialKillCount = state?.uescKillCount ?? null;
+
+  return (
+    <main className="px-4 sm:px-8 max-w-[1200px] mx-auto py-8 sm:py-16">
+      <MarathonClient initialKillCount={initialKillCount} />
     </main>
   );
 }


### PR DESCRIPTION
## Summary

Builds the full **/marathon** metrics page and relocates all game metric visualizations from the cryoarchive dashboard.

**Closes #79** (depends on #76 hooks merged via #81, #77 nav merged via #82)

## Changes

### New: `/marathon` metrics page
- **`MarathonClient.tsx`** — client component with:
  - Kill count hero stat (click to refresh)
  - ETA to 500M projection (`KillCountEta`)
  - Kill count over time chart (`KillCountChart`)
  - Steam players over time chart (`PlayerCountChart`)
  - Kill analytics dashboard (`KillAnalytics`)
  - Synced time range between kill and player charts
  - Quick links to Weapons Database and cryoarchive.systems
- **`page.tsx`** — server component with SSR-hydrated kill count via `fetchState()`
- **`loading.tsx`** — skeleton loading state
- **`error.tsx`** — error boundary with retry

### Modified: Cryoarchive dashboard
- Removed chart/analytics sections (KillCountChart, PlayerCountChart, KillAnalytics, KillCountEta)
- Kill count display becomes a clickable card linking to `/marathon` with "VIEW FULL METRICS →"
- Removed all `dynamic()` imports for chart components
- All ARG-specific content remains: sectors, memory flags, trailer, ship date, polling

### Reused from #76
All data hooks (`useKillCountData`, `useSteamPlayers`, `useChartRange`) imported from `@/hooks`

## Validation
- ✅ `npm run lint` — clean
- ✅ `npm run test` — 73/73 pass
- ✅ `npm run build` — compiles, `/marathon` renders as dynamic route
- All existing URLs preserved (no routes removed)