### PR TITLE
feat: Redesign homepage for The Breacher Network (#78)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,246 +1,158 @@
 import Image from "next/image";
 import Link from "next/link";
-import { fetchState, fetchStabilization, fetchSteamPlayerCount } from "@/lib/api";
-import { SECTOR_NAMES } from "@/lib/types";
+import { fetchSteamPlayerCount } from "@/lib/api";
 import { URLS } from "@/lib/urls";
 
 export const revalidate = 60;
 
 export default async function HomePage() {
-  const [state, stabilization, steamPlayers] = await Promise.all([
-    fetchState(),
-    fetchStabilization(),
-    fetchSteamPlayerCount(),
-  ]);
-
-  const killCount = state?.uescKillCount ?? null;
-  const sectorsUnlocked = state
-    ? SECTOR_NAMES.filter((s) => state.pages[s]?.unlocked).length
-    : null;
-  const sectorsCompleted = state
-    ? SECTOR_NAMES.filter((s) => state.pages[s]?.completed).length
-    : null;
-  const totalSectors = SECTOR_NAMES.length;
-
-  const avgStabilization = stabilization
-    ? Math.round(
-      Object.values(stabilization).reduce(
-        (sum, c) => sum + c.stabilizationLevel,
-        0
-      ) / Object.values(stabilization).length
-    )
-    : null;
+  const steamPlayers = await fetchSteamPlayerCount();
 
   return (
     <main className="max-w-5xl mx-auto px-4 sm:px-8 py-8 sm:py-16">
-      {/* Hero */}
-      <div className="text-center mb-12 sm:mb-16">
+      {/* ── Hero ── */}
+      <div className="text-center mb-10 sm:mb-14">
         <div className="flex justify-center mb-6">
           <Image
             src="/logo.svg"
             alt=""
-            width={64}
-            height={58}
-            className="w-16 h-auto drop-shadow-[0_0_12px_rgba(3,138,223,0.5)]"
+            width={72}
+            height={65}
+            className="w-[72px] h-auto drop-shadow-[0_0_16px_rgba(3,138,223,0.5)]"
             priority
           />
         </div>
-        <h1 className="font-[var(--font-display)] text-3xl sm:text-5xl font-black text-accent glow-accent tracking-[6px] mb-4">
+        <h1 className="font-[var(--font-display)] text-3xl sm:text-5xl font-black text-accent glow-accent tracking-[6px] mb-3">
           BREACHER<span className="text-accent2">{"//"}</span>NET
         </h1>
-        <p className="font-[var(--font-display)] text-lg sm:text-xl font-bold text-text-heading tracking-[4px] mb-2">
+        <p className="font-[var(--font-display)] text-base sm:text-xl font-bold text-text-heading tracking-[4px] mb-2">
+          THE BREACHER NETWORK
+        </p>
+        <p className="font-[var(--font-display)] text-xs sm:text-sm text-dim tracking-[3px] mb-4">
           BREACHERS OF TOMORROW
         </p>
-        <p className="text-dim text-sm sm:text-base tracking-[2px] max-w-2xl mx-auto">
-          COMMUNITY HUB &amp; LIVE TRACKER FOR THE MARATHON ARG
+        <p className="font-[var(--font-display)] text-[0.65rem] sm:text-xs tracking-[5px] text-accent2/70">
+          CONNECT{" "}
+          <span className="text-border mx-1">{"//"}
+          </span>{" "}BUILD{" "}
+          <span className="text-border mx-1">{"//"}
+          </span>{" "}RUN
         </p>
       </div>
 
-      {/* Quick Status */}
-      {state && (
-        <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 mb-12">
-          <div className="cryo-panel p-6 text-center">
-            <div className="font-[var(--font-display)] text-[0.6rem] tracking-[3px] text-dim mb-2">
-              UESC KILL COUNT
-            </div>
-            <div className="font-[var(--font-display)] text-2xl font-black text-danger glow-danger">
-              {killCount?.toLocaleString()}
-            </div>
-          </div>
-
-          <div className="cryo-panel p-6 text-center">
-            <div className="font-[var(--font-display)] text-[0.6rem] tracking-[3px] text-dim mb-2">
-              SECTORS
-            </div>
-            <div className="font-[var(--font-display)] text-2xl font-bold text-accent glow-accent">
-              {sectorsCompleted}/{totalSectors}
-              <span className="text-dim text-sm ml-2">COMPLETED</span>
-            </div>
-            <div className="text-xs text-dim mt-1">
-              {sectorsUnlocked}/{totalSectors} unlocked
-            </div>
-          </div>
-
-          <div className="cryo-panel p-6 text-center">
-            <div className="font-[var(--font-display)] text-[0.6rem] tracking-[3px] text-dim mb-2">
-              AVG STABILIZATION
-            </div>
-            <div className="font-[var(--font-display)] text-2xl font-bold text-accent2 glow-accent2">
-              {avgStabilization !== null ? `${avgStabilization}%` : "--"}
-            </div>
-          </div>
-
-          <div className="cryo-panel p-6 text-center">
-            <div className="font-[var(--font-display)] text-[0.6rem] tracking-[3px] text-dim mb-2">
-              STEAM PLAYERS
-            </div>
-            <div className="font-[var(--font-display)] text-2xl font-bold text-mint glow-mint">
-              {steamPlayers !== null ? steamPlayers.toLocaleString() : "--"}
-            </div>
-            <div className="text-xs text-dim mt-1">online now</div>
-          </div>
+      {/* ── Live Status Strip ── */}
+      <div className="flex items-center justify-center gap-6 sm:gap-10 mb-12 sm:mb-14 flex-wrap">
+        <div className="flex items-center gap-2.5">
+          <div className="w-2 h-2 rounded-full bg-mint animate-pulse" />
+          <span className="font-[var(--font-display)] text-[0.6rem] tracking-[3px] text-dim">
+            STEAM PLAYERS
+          </span>
+          <span className="font-[var(--font-display)] text-sm font-bold text-mint glow-mint tracking-wider">
+            {steamPlayers !== null ? steamPlayers.toLocaleString() : "—"}
+          </span>
         </div>
-      )}
-
-      {/* Navigation Cards */}
-      <div className="section-title">CRYOARCHIVE TOOLS</div>
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-12">
-        <NavCard
-          href="/cryoarchive"
-          icon="📡"
-          title="DASHBOARD"
-          description="Live kill count, sector states, ship date countdown, and kill rate chart"
-        />
-        <NavCard
-          href="/cryoarchive/cameras"
-          icon="📷"
-          title="CAMERAS"
-          description="CCTV stabilization levels across all sectors and cameras"
-        />
-        <NavCard
-          href="/cryoarchive/maps"
-          icon="🗺️"
-          title="MAPS"
-          description="Interactive maps of Perimeter, Dire Marsh, and Outpost"
-        />
-        <NavCard
-          href="/cryoarchive/index"
-          icon="📂"
-          title="INDEX ARCHIVE"
-          description="Cryoarchive entry index — types, lock status, and unlock tracking"
-        />
-        <NavCard
-          href="/cryoarchive/changes"
-          icon="🔄"
-          title="SITE CHANGES"
-          description="Detected website deployments and build changes"
-        />
+        <div className="flex items-center gap-2.5">
+          <div className="w-2 h-2 rounded-full bg-accent2 animate-pulse" />
+          <span className="font-[var(--font-display)] text-[0.6rem] tracking-[3px] text-dim">
+            DATA FEED
+          </span>
+          <Link
+            href="/status"
+            className="font-[var(--font-display)] text-[0.6rem] tracking-[2px] text-accent2 hover:glow-accent2 transition-all no-underline"
+          >
+            ONLINE
+          </Link>
+        </div>
       </div>
 
-      {/* Community Links */}
-      <div className="section-title">COMMUNITY</div>
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-12">
-        <a
-          href={URLS.wiki}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="cryo-panel p-6 flex items-center gap-4 hover:border-accent transition-colors no-underline group"
-        >
-          <div className="shrink-0" aria-hidden="true">
-            <Image src="/wiki-logo.svg" alt="" width={32} height={32} className="w-8 h-8" />
-          </div>
-          <div>
-            <div className="font-[var(--font-display)] text-xs tracking-[3px] text-accent group-hover:glow-accent mb-1">
-              WIKI
-            </div>
-            <div className="text-sm text-dim">
-              Marathon lore, sectors, characters, and resources
-            </div>
-          </div>
-          <div className="ml-auto text-accent2 font-[var(--font-display)] text-lg group-hover:translate-x-1 transition-transform">
-            →
-          </div>
-        </a>
-        <a
+      {/* ── BREACHER NET — Community ── */}
+      <div className="section-title">BREACHER NET</div>
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-12">
+        <ExternalCard
           href={URLS.discord}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="cryo-panel p-6 flex items-center gap-4 hover:border-accent transition-colors no-underline group"
-        >
-          <div className="text-3xl" aria-hidden="true">💬</div>
-          <div>
-            <div className="font-[var(--font-display)] text-xs tracking-[3px] text-accent group-hover:glow-accent mb-1">
-              DISCORD
-            </div>
-            <div className="text-sm text-dim">
-              Join the Breachers of Tomorrow community
-            </div>
-          </div>
-          <div className="ml-auto text-accent2 font-[var(--font-display)] text-lg group-hover:translate-x-1 transition-transform">
-            →
-          </div>
-        </a>
-        <a
-          href={URLS.communityDoc}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="cryo-panel p-6 flex items-center gap-4 hover:border-accent transition-colors no-underline group"
-        >
-          <div className="text-3xl" aria-hidden="true">📋</div>
-          <div>
-            <div className="font-[var(--font-display)] text-xs tracking-[3px] text-accent group-hover:glow-accent mb-1">
-              COMMUNITY DOC
-            </div>
-            <div className="text-sm text-dim">
-              Current objectives and Breach Protocol notes
-            </div>
-          </div>
-          <div className="ml-auto text-accent2 font-[var(--font-display)] text-lg group-hover:translate-x-1 transition-transform">
-            →
-          </div>
-        </a>
-        <a
-          href={URLS.winnower}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="cryo-panel p-6 flex items-center gap-4 hover:border-accent transition-colors no-underline group"
-        >
-          <div className="text-3xl" aria-hidden="true">🌱</div>
-          <div>
-            <div className="font-[var(--font-display)] text-xs tracking-[3px] text-accent group-hover:glow-accent mb-1">
-              WINNOWER GARDEN
-            </div>
-            <div className="text-sm text-dim">
-              Historical ARG data archive — full history from day one
-            </div>
-          </div>
-          <div className="ml-auto text-accent2 font-[var(--font-display)] text-lg group-hover:translate-x-1 transition-transform">
-            →
-          </div>
-        </a>
-        <a
-          href={URLS.weaponsDb}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="cryo-panel p-6 flex items-center gap-4 hover:border-accent transition-colors no-underline group"
-        >
-          <div className="text-3xl" aria-hidden="true">🔫</div>
-          <div>
-            <div className="font-[var(--font-display)] text-xs tracking-[3px] text-accent group-hover:glow-accent mb-1">
-              WEAPONS DATABASE
-            </div>
-            <div className="text-sm text-dim">
-              Community weapon and mod tracker with loadout info
-            </div>
-          </div>
-          <div className="ml-auto text-accent2 font-[var(--font-display)] text-lg group-hover:translate-x-1 transition-transform">
-            →
-          </div>
-        </a>
+          icon="💬"
+          title="DISCORD"
+          description="Join 1,500+ Breachers — the primary community hub"
+        />
+        <ExternalCard
+          href={URLS.wiki}
+          title="WIKI"
+          description="Marathon lore, sectors, characters, and resources"
+          customIcon={
+            <Image
+              src="/wiki-logo.svg"
+              alt=""
+              width={28}
+              height={28}
+              className="w-7 h-7"
+            />
+          }
+        />
+        <NavCard
+          href="/contribute"
+          icon="🛠️"
+          title="CONTRIBUTE"
+          description="Help build breacher.net — code, content, or ideas"
+        />
       </div>
 
-      {/* Footer */}
-      <footer className="border-t border-border pt-6 text-center text-xs text-dim tracking-[2px]" role="contentinfo">
+      {/* ── MARATHON — Game Content ── */}
+      <div className="section-title">MARATHON</div>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-12">
+        <NavCard
+          href="/marathon"
+          icon="📊"
+          title="METRICS"
+          description="Kill counts, player data, analytics, and 500M ETA projection"
+          accent="danger"
+        />
+        <ExternalCard
+          href={URLS.weaponsDb}
+          icon="🔫"
+          title="WEAPONS DATABASE"
+          description="Community weapon and mod tracker with loadout info"
+        />
+        <ComingSoonCard
+          title="INTERACTIVE MAPS"
+          description="Collaborative raid maps with callouts and routes"
+        />
+        <ComingSoonCard
+          title="RAID GUIDES"
+          description="Community-written strategy guides for Marathon raids"
+        />
+      </div>
+
+      {/* ── CRYOARCHIVE — ARG Achievement ── */}
+      <div className="section-title">CRYOARCHIVE</div>
+      <div className="mb-12">
+        <Link
+          href="/cryoarchive"
+          className="cryo-panel p-6 flex items-center gap-5 hover:border-accent/30 transition-colors no-underline group block"
+        >
+          <div className="absolute top-0 left-0 right-0 h-0.5 bg-gradient-to-r from-accent2 via-accent to-transparent" />
+          <div className="text-3xl shrink-0 drop-shadow-[0_0_8px_rgba(0,212,255,0.4)]" aria-hidden="true">
+            📡
+          </div>
+          <div className="flex-1">
+            <div className="font-[var(--font-display)] text-xs tracking-[3px] text-accent group-hover:glow-accent mb-1">
+              CRYOARCHIVE DASHBOARD
+            </div>
+            <div className="text-sm text-dim">
+              Sector states, cameras, maps, index archive, and site changes
+              — the community&apos;s complete ARG tracking archive
+            </div>
+          </div>
+          <div className="ml-auto text-accent2 font-[var(--font-display)] text-lg group-hover:translate-x-1 transition-transform shrink-0">
+            →
+          </div>
+        </Link>
+      </div>
+
+      {/* ── Footer ── */}
+      <footer
+        className="border-t border-border pt-6 text-center text-xs text-dim tracking-[2px]"
+        role="contentinfo"
+      >
         <p>
           BUILT BY{" "}
           <a
@@ -280,34 +192,127 @@ export default async function HomePage() {
   );
 }
 
+/* ------------------------------------------------------------------ */
+/*  Card components                                                    */
+/* ------------------------------------------------------------------ */
+
 function NavCard({
   href,
   icon,
   title,
   description,
+  accent,
 }: {
   href: string;
   icon: string;
   title: string;
   description: string;
+  accent?: "danger" | "mint" | "accent2";
 }) {
+  const titleColor =
+    accent === "danger"
+      ? "text-danger group-hover:glow-danger"
+      : accent === "mint"
+        ? "text-mint group-hover:glow-mint"
+        : accent === "accent2"
+          ? "text-accent2 group-hover:glow-accent2"
+          : "text-accent group-hover:glow-accent";
+
   return (
     <Link
       href={href}
       className="cryo-panel p-6 flex items-center gap-4 hover:border-accent transition-colors no-underline group"
     >
-      <div className="text-3xl shrink-0 drop-shadow-[0_0_8px_rgba(0,212,255,0.4)]" aria-hidden="true">
+      <div
+        className="text-3xl shrink-0 drop-shadow-[0_0_8px_rgba(0,212,255,0.4)]"
+        aria-hidden="true"
+      >
         {icon}
       </div>
+      <div className="flex-1">
+        <div
+          className={`font-[var(--font-display)] text-xs tracking-[3px] ${titleColor} mb-1`}
+        >
+          {title}
+        </div>
+        <div className="text-sm text-dim">{description}</div>
+      </div>
+      <div className="ml-auto text-accent2 font-[var(--font-display)] text-lg group-hover:translate-x-1 transition-transform shrink-0">
+        →
+      </div>
+    </Link>
+  );
+}
+
+function ExternalCard({
+  href,
+  icon,
+  customIcon,
+  title,
+  description,
+}: {
+  href: string;
+  icon?: string;
+  customIcon?: React.ReactNode;
+  title: string;
+  description: string;
+}) {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="cryo-panel p-6 flex items-center gap-4 hover:border-accent transition-colors no-underline group"
+    >
+      {customIcon ? (
+        <div className="shrink-0" aria-hidden="true">
+          {customIcon}
+        </div>
+      ) : (
+        <div
+          className="text-3xl shrink-0 drop-shadow-[0_0_8px_rgba(0,212,255,0.4)]"
+          aria-hidden="true"
+        >
+          {icon}
+        </div>
+      )}
       <div className="flex-1">
         <div className="font-[var(--font-display)] text-xs tracking-[3px] text-accent group-hover:glow-accent mb-1">
           {title}
         </div>
         <div className="text-sm text-dim">{description}</div>
       </div>
-      <div className="ml-auto text-accent2 font-[var(--font-display)] text-lg group-hover:translate-x-1 transition-transform">
-        →
+      <div className="ml-auto text-accent2 font-[var(--font-display)] text-lg group-hover:translate-x-1 transition-transform shrink-0">
+        ↗
       </div>
-    </Link>
+    </a>
+  );
+}
+
+function ComingSoonCard({
+  title,
+  description,
+}: {
+  title: string;
+  description: string;
+}) {
+  return (
+    <div className="cryo-panel p-6 flex items-center gap-4 opacity-60 border-dashed">
+      <div
+        className="text-2xl shrink-0 grayscale opacity-50"
+        aria-hidden="true"
+      >
+        🚧
+      </div>
+      <div className="flex-1">
+        <div className="font-[var(--font-display)] text-xs tracking-[3px] text-dim mb-1 flex items-center gap-2">
+          {title}
+          <span className="font-[var(--font-display)] text-[0.5rem] tracking-[2px] px-2 py-0.5 border border-border text-dim/60">
+            COMING SOON
+          </span>
+        </div>
+        <div className="text-sm text-dim/70">{description}</div>
+      </div>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary

Redesigns the homepage to reflect the community pivot from ARG tracker to **The Breacher Network** — a community hub for Marathon players.

**Closes #78** (part of epic #75, depends on #77 nav + #79 marathon page)

## New Homepage Layout

### 1. Hero
- BREACHER//NET logo (larger, 72px)
- **"THE BREACHER NETWORK"** as main tagline (replaces "BREACHERS OF TOMORROW" as primary)
- "BREACHERS OF TOMORROW" as community name subtitle
- "CONNECT // BUILD // RUN" motto in accent2

### 2. Live Status Strip
- Steam player count with live indicator dot
- Data feed status with link to `/status` page
- Compact horizontal layout, centered

### 3. BREACHER NET Section (3-col)
- Discord — "Join 1,500+ Breachers"
- Wiki — with `wiki-logo.svg` custom icon
- Contribute — internal link to `/contribute`

### 4. MARATHON Section (2-col)
- **Metrics** — links to `/marathon` (danger accent for kill data)
- **Weapons Database** — external link
- **Interactive Maps** — Coming Soon card (dashed border, muted)
- **Raid Guides** — Coming Soon card

### 5. CRYOARCHIVE Section
- Single dashboard card with gradient accent bar
- Framed as the community's complete ARG tracking archive
- Links to `/cryoarchive`

### 6. Footer
- Attribution preserved (Breachers, CrowdTypical, Winnower)

## What Changed
- Removed the 4-stat quick status grid (kill count, sectors, stabilization, steam players)
- Removed individual cryoarchive tool cards from homepage
- Removed Winnower/Tau Ceti/Community Doc from homepage (accessible via nav RESOURCES)
- Homepage now only fetches Steam player count (no DB queries needed)
- Three reusable card components: `NavCard`, `ExternalCard`, `ComingSoonCard`

## Validation
- ✅ `npm run lint` — clean
- ✅ `npm run test` — 73/73 pass
- ✅ `npm run build` — compiles, homepage remains static with 1m revalidation
- All existing URLs preserved (no routes removed)