### PR TITLE
chore: Update site metadata and taglines for post-ARG identity (#80)

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -6,11 +6,11 @@ import { SITE_URL } from "@/lib/urls";
 export const metadata: Metadata = {
   title: "About",
   description:
-    "Breachers of Tomorrow — a 1,000+ member community tracking the Marathon ARG. Who we are, what we do, and how to join.",
+    "Breachers of Tomorrow — a 1,500+ member community and The Breacher Network for Marathon by Bungie. Who we are, what we do, and how to join.",
   openGraph: {
     title: "About // BREACHER.NET",
     description:
-      "Breachers of Tomorrow — a 1,000+ member community tracking the Marathon ARG.",
+      "Breachers of Tomorrow — a 1,500+ member community behind The Breacher Network.",
     url: `${SITE_URL}/about`,
   },
 };
@@ -24,7 +24,7 @@ export default function AboutPage() {
           BREACHERS OF TOMORROW
         </h1>
         <p className="text-dim text-sm sm:text-base tracking-[2px] max-w-2xl mx-auto">
-          COMMUNITY TRACKER AND HUB FOR THE MARATHON ARG
+          THE BREACHER NETWORK — MARATHON COMMUNITY HUB
         </p>
       </div>
 
@@ -34,7 +34,7 @@ export default function AboutPage() {
         <div className="cryo-panel p-6 sm:p-8 space-y-4">
           <p className="text-foreground text-sm sm:text-base leading-relaxed">
             <strong className="text-accent">Breachers of Tomorrow</strong> is a
-            1,000+ member community built around the{" "}
+            1,500+ member community built around the{" "}
             <a
               href={URLS.cryoarchive}
               target="_blank"

--- a/src/app/community/page.tsx
+++ b/src/app/community/page.tsx
@@ -35,7 +35,7 @@ export default function CommunityPage() {
           <ResourceCard
             icon="💬"
             title="DISCORD"
-            description="The heart of Breachers of Tomorrow. 1,000+ members solving puzzles, sharing discoveries, and coordinating research."
+            description="The heart of Breachers of Tomorrow. 1,500+ members solving puzzles, sharing discoveries, and coordinating research."
             href={URLS.discord}
             cta="JOIN SERVER"
             accent

--- a/src/app/cryoarchive/page.tsx
+++ b/src/app/cryoarchive/page.tsx
@@ -5,11 +5,11 @@ import { DashboardClient } from "./DashboardClient";
 import { SITE_URL } from "@/lib/urls";
 
 export const metadata: Metadata = {
-  title: "Dashboard",
-  description: "Live kill count, sector states, ship date countdown, and kill rate chart",
+  title: "Cryoarchive Dashboard",
+  description: "The Breacher Network's ARG archive — live kill count, sector states, ship date countdown, and kill rate analytics.",
   openGraph: {
-    title: "Dashboard // BREACHER.NET",
-    description: "Live kill count, sector states, ship date countdown, and kill rate chart",
+    title: "Cryoarchive Dashboard // BREACHER.NET",
+    description: "The Breacher Network's ARG archive — live kill count, sector states, ship date countdown, and kill rate analytics.",
     url: `${SITE_URL}/cryoarchive`,
   },
 };

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -17,12 +17,22 @@ const spaceGrotesk = Space_Grotesk({
 export const metadata: Metadata = {
   metadataBase: new URL(SITE_URL),
   title: {
-    default: "BREACHER.NET // Breachers of Tomorrow",
+    default: "BREACHER.NET // The Breacher Network",
     template: "%s // BREACHER.NET",
   },
   description:
-    "Community tracker and hub for the Marathon ARG — Breachers of Tomorrow",
-  keywords: ["marathon", "arg", "bungie", "cryoarchive", "breach protocol"],
+    "The Breacher Network — Marathon community hub by Breachers of Tomorrow. Game metrics, ARG archive, wiki, weapons database, and 1,500+ members.",
+  keywords: [
+    "marathon",
+    "bungie",
+    "breacher network",
+    "breachers of tomorrow",
+    "arg",
+    "cryoarchive",
+    "kill count",
+    "weapons database",
+    "community",
+  ],
   icons: {
     icon: [
       { url: "/favicon.ico", sizes: "any" },
@@ -36,23 +46,23 @@ export const metadata: Metadata = {
     locale: "en_US",
     url: SITE_URL,
     siteName: "BREACHER.NET",
-    title: "BREACHER.NET // Breachers of Tomorrow",
+    title: "BREACHER.NET // The Breacher Network",
     description:
-      "Community tracker and hub for the Marathon ARG — live kill count, sector states, stabilization data, and interactive maps.",
+      "The Breacher Network — Marathon community hub. Game metrics, kill count tracking, ARG archive, wiki, weapons database, and 1,500+ members.",
     images: [
       {
         url: "/og-image.png",
         width: 1200,
         height: 630,
-        alt: "BREACHER//NET — Community hub for the Marathon ARG",
+        alt: "BREACHER//NET — The Breacher Network",
       },
     ],
   },
   twitter: {
     card: "summary_large_image",
-    title: "BREACHER.NET // Breachers of Tomorrow",
+    title: "BREACHER.NET // The Breacher Network",
     description:
-      "Community tracker and hub for the Marathon ARG — live kill count, sector states, stabilization data, and interactive maps.",
+      "The Breacher Network — Marathon community hub. Game metrics, kill count tracking, ARG archive, wiki, weapons database, and 1,500+ members.",
     images: ["/og-image.png"],
   },
   alternates: {

--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -2,10 +2,10 @@ import type { MetadataRoute } from "next";
 
 export default function manifest(): MetadataRoute.Manifest {
   return {
-    name: "BREACHER.NET — Breachers of Tomorrow",
+    name: "BREACHER.NET — The Breacher Network",
     short_name: "BREACHER.NET",
     description:
-      "Community tracker and hub for the Marathon ARG — live kill count, sector states, stabilization data, and interactive maps.",
+      "The Breacher Network — Marathon community hub. Game metrics, ARG archive, wiki, weapons database, and 1,500+ members.",
     start_url: "/",
     display: "standalone",
     background_color: "#060D11",

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -60,5 +60,23 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: "daily",
       priority: 0.8,
     },
+    {
+      url: `${baseUrl}/contribute`,
+      lastModified: now,
+      changeFrequency: "monthly",
+      priority: 0.5,
+    },
+    {
+      url: `${baseUrl}/status`,
+      lastModified: now,
+      changeFrequency: "always",
+      priority: 0.4,
+    },
+    {
+      url: `${baseUrl}/api-docs`,
+      lastModified: now,
+      changeFrequency: "monthly",
+      priority: 0.4,
+    },
   ];
 }


### PR DESCRIPTION
## Summary

Updates all site metadata, OG tags, and page descriptions to reflect The Breacher Network's evolution from ARG tracker to community hub.

**Closes #80**

## Changes

- Root layout: title, description, OG, Twitter, keywords
- Manifest: PWA name + description
- About page: 1,000+ → 1,500+ members, updated hero/description
- Community page: updated hero text
- Cryoarchive pages: framed as ARG archive
- Sitemap: added /status, /contribute, /api-docs

## Validation
- lint, test (73/73), build all pass