### PR TITLE
feat(poller): add JSON buffer for DB outage resilience

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,10 @@ POSTGRES_PASSWORD=changeme
 
 # For direct app connection (outside docker-compose)
 DATABASE_URL=postgresql://breacher:changeme@localhost:5432/breacher
+
+# ── Poller buffer (safety net when DB is unavailable) ──
+# Directory for JSONL buffer files.  Mount a volume here in K8s.
+# POLLER_BUFFER_DIR=/data/buffer
+#
+# Max size per buffer file in bytes (default: 50 MiB).  Set to 0 for unlimited.
+# POLLER_BUFFER_MAX_BYTES=52428800

--- a/poller/Dockerfile
+++ b/poller/Dockerfile
@@ -21,7 +21,11 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 
+# Create buffer directory for local data safety net
+RUN mkdir -p /data/buffer
+
 RUN useradd --system --uid 1001 poller
+RUN chown -R poller:poller /data/buffer
 USER poller
 
 CMD ["supercronic", "crontab"]

--- a/poller/buffer.py
+++ b/poller/buffer.py
@@ -1,0 +1,200 @@
+"""Local JSON buffer for poller data when the database is unavailable.
+
+Provides a safety net so data polled from upstream APIs is never lost due
+to transient database outages.  Each write attempt that fails is appended
+to a local JSONL file (one JSON object per line).  On the next successful
+DB connection, buffered rows are flushed first.
+
+File layout::
+
+    /data/buffer/state_snapshots.jsonl
+    /data/buffer/stabilization_snapshots.jsonl
+    /data/buffer/steam_snapshots.jsonl
+    /data/buffer/build_events.jsonl
+    /data/buffer/index_entries.jsonl
+    /data/buffer/index_snapshots.jsonl
+
+Environment variables:
+
+    POLLER_BUFFER_DIR
+        Directory for buffer files.  Defaults to ``/data/buffer``.
+        Mount a persistent volume here in K8s.
+
+    POLLER_BUFFER_MAX_BYTES
+        Maximum size in bytes per buffer file.  When a file exceeds this
+        limit, the oldest lines are dropped to make room.  Defaults to
+        ``52428800`` (50 MiB).  Set to ``0`` to disable the size cap.
+"""
+
+import json
+import logging
+import os
+import tempfile
+from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+BUFFER_DIR = Path(os.environ.get("POLLER_BUFFER_DIR", "/data/buffer"))
+BUFFER_MAX_BYTES = int(os.environ.get("POLLER_BUFFER_MAX_BYTES", str(50 * 1024 * 1024)))
+
+
+def _buffer_path(table: str) -> Path:
+    """Return the buffer file path for a given table name."""
+    safe = table.replace("/", "_").replace("..", "_")
+    return BUFFER_DIR / f"{safe}.jsonl"
+
+
+def _ensure_dir() -> None:
+    """Create the buffer directory if it doesn't exist."""
+    BUFFER_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def _enforce_max_size(path: Path) -> None:
+    """Trim oldest lines from *path* until it fits within BUFFER_MAX_BYTES.
+
+    Strategy: when the file exceeds the limit, keep only the newest lines
+    that fit within the cap.  This is an O(n) operation but only triggers
+    on overflow, which should be rare in practice.
+    """
+    if BUFFER_MAX_BYTES <= 0:
+        return  # no cap
+
+    try:
+        size = path.stat().st_size
+    except FileNotFoundError:
+        return
+
+    if size <= BUFFER_MAX_BYTES:
+        return
+
+    log.warning(
+        "Buffer %s exceeds max size (%d > %d bytes) — trimming oldest entries",
+        path.name, size, BUFFER_MAX_BYTES,
+    )
+
+    # Read all lines and keep the tail that fits
+    with open(path, "r") as f:
+        lines = f.readlines()
+
+    kept: list[str] = []
+    kept_size = 0
+    for line in reversed(lines):
+        line_bytes = len(line.encode("utf-8"))
+        if kept_size + line_bytes > BUFFER_MAX_BYTES:
+            break
+        kept.append(line)
+        kept_size += line_bytes
+
+    kept.reverse()
+    dropped = len(lines) - len(kept)
+
+    # Atomic write: write to temp file then rename
+    tmp_fd, tmp_path = tempfile.mkstemp(dir=BUFFER_DIR, suffix=".tmp")
+    try:
+        with os.fdopen(tmp_fd, "w") as tmp:
+            tmp.writelines(kept)
+        os.replace(tmp_path, str(path))
+    except Exception:
+        # Clean up temp file on failure
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+    log.info("Trimmed %d oldest entries from %s (kept %d)", dropped, path.name, len(kept))
+
+
+def buffer_row(table: str, params: dict) -> None:
+    """Append a single row to the buffer file for *table*.
+
+    Parameters
+    ----------
+    table:
+        Database table name (e.g. ``"state_snapshots"``).
+    params:
+        Dictionary of column names → values.  Values must be
+        JSON-serializable.  Timestamps should be ISO 8601 strings.
+    """
+    _ensure_dir()
+    path = _buffer_path(table)
+
+    row = {"table": table, "params": params}
+    line = json.dumps(row, default=str) + "\n"
+
+    try:
+        with open(path, "a") as f:
+            f.write(line)
+        log.debug("Buffered 1 row to %s", path.name)
+    except Exception:
+        log.exception("Failed to write buffer file %s", path.name)
+        return
+
+    # Enforce size cap after write
+    try:
+        _enforce_max_size(path)
+    except Exception:
+        log.exception("Failed to trim buffer file %s", path.name)
+
+
+def read_buffered(table: str) -> list[dict]:
+    """Read all buffered rows for *table*.  Returns a list of param dicts."""
+    path = _buffer_path(table)
+    if not path.exists():
+        return []
+
+    rows: list[dict] = []
+    with open(path, "r") as f:
+        for lineno, line in enumerate(f, 1):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+                rows.append(obj.get("params", obj))
+            except json.JSONDecodeError:
+                log.warning("Skipping corrupt buffer line %d in %s", lineno, path.name)
+    return rows
+
+
+def clear_buffer(table: str) -> int:
+    """Remove the buffer file for *table*.  Returns the number of rows cleared."""
+    path = _buffer_path(table)
+    if not path.exists():
+        return 0
+
+    count = 0
+    with open(path, "r") as f:
+        for line in f:
+            if line.strip():
+                count += 1
+
+    path.unlink()
+    log.info("Cleared %d buffered rows from %s", count, path.name)
+    return count
+
+
+def buffered_count(table: str) -> int:
+    """Return the number of buffered rows for *table* without loading them."""
+    path = _buffer_path(table)
+    if not path.exists():
+        return 0
+
+    count = 0
+    with open(path, "r") as f:
+        for line in f:
+            if line.strip():
+                count += 1
+    return count
+
+
+def buffered_tables() -> list[str]:
+    """Return a list of table names that have buffered data."""
+    if not BUFFER_DIR.exists():
+        return []
+
+    tables = []
+    for p in BUFFER_DIR.glob("*.jsonl"):
+        if p.stat().st_size > 0:
+            tables.append(p.stem)
+    return tables

--- a/poller/db_writer.py
+++ b/poller/db_writer.py
@@ -1,0 +1,259 @@
+"""Shared database helpers with automatic buffer fallback.
+
+Wraps psycopg2 operations so that:
+1. Before any insert, buffered rows for that table are flushed first
+2. If the DB is unreachable, the row is saved to the local JSON buffer
+3. Heartbeats are recorded with buffer status metadata
+
+Usage::
+
+    from db_writer import insert_row, record_heartbeat
+
+    insert_row(
+        table="state_snapshots",
+        columns=["kill_count", "ship_date", "raw_response"],
+        values=[476291, "JUL 23 2026", '{"state": {...}}'],
+        params_dict={"kill_count": 476291, "ship_date": "JUL 23 2026", ...},
+    )
+"""
+
+import json
+import logging
+import os
+
+import psycopg2
+
+from buffer import (
+    buffer_row,
+    buffered_count,
+    buffered_tables,
+    clear_buffer,
+    read_buffered,
+)
+
+log = logging.getLogger(__name__)
+
+DATABASE_URL = os.environ.get(
+    "DATABASE_URL",
+    "postgresql://breacher:mycomplexpassword@db:5432/breacher",
+)
+
+
+def get_db():
+    """Get a database connection."""
+    return psycopg2.connect(DATABASE_URL)
+
+
+def _try_connect():
+    """Attempt a DB connection.  Returns (conn, None) or (None, error)."""
+    try:
+        conn = psycopg2.connect(DATABASE_URL)
+        return conn, None
+    except Exception as e:
+        return None, e
+
+
+def _flush_buffer(conn, table: str) -> int:
+    """Flush buffered rows for *table* into the database.
+
+    Returns the number of rows successfully flushed.
+    """
+    rows = read_buffered(table)
+    if not rows:
+        return 0
+
+    flushed = 0
+    for row in rows:
+        columns = list(row.keys())
+        values = list(row.values())
+        placeholders = ", ".join(["%s"] * len(columns))
+        col_names = ", ".join(columns)
+        sql = f"INSERT INTO {table} ({col_names}) VALUES ({placeholders})"
+
+        try:
+            with conn.cursor() as cur:
+                cur.execute(sql, values)
+            conn.commit()
+            flushed += 1
+        except Exception:
+            conn.rollback()
+            log.warning("Failed to flush buffered row to %s — stopping flush", table)
+            break
+
+    if flushed == len(rows):
+        clear_buffer(table)
+        log.info("Flushed all %d buffered rows to %s", flushed, table)
+    elif flushed > 0:
+        # Partial flush: rewrite buffer with remaining rows
+        clear_buffer(table)
+        for remaining_row in rows[flushed:]:
+            buffer_row(table, remaining_row)
+        log.info(
+            "Partially flushed %d/%d buffered rows to %s",
+            flushed, len(rows), table,
+        )
+
+    return flushed
+
+
+def insert_row(
+    table: str,
+    columns: list[str],
+    values: list,
+    *,
+    params_dict: dict | None = None,
+    on_conflict: str = "",
+) -> bool:
+    """Insert a row into *table*, falling back to buffer on failure.
+
+    Parameters
+    ----------
+    table:
+        Target table name.
+    columns:
+        Column names for the INSERT.
+    values:
+        Corresponding values (same order as *columns*).
+    params_dict:
+        Optional dict representation for buffering.  If not provided,
+        one is built from *columns* and *values*.
+    on_conflict:
+        Optional ``ON CONFLICT ...`` clause appended to the INSERT.
+
+    Returns True if the row was written to the DB, False if buffered.
+    """
+    if params_dict is None:
+        params_dict = {}
+        for col, val in zip(columns, values):
+            # Serialize non-primitive types for JSON storage
+            if isinstance(val, (dict, list)):
+                params_dict[col] = val
+            else:
+                params_dict[col] = val
+
+    conn, err = _try_connect()
+    if conn is None:
+        log.warning("DB unavailable (%s) — buffering row for %s", err, table)
+        buffer_row(table, params_dict)
+        return False
+
+    try:
+        # Flush any previously buffered rows first
+        _flush_buffer(conn, table)
+
+        # Now insert the current row
+        placeholders = ", ".join(["%s"] * len(columns))
+        col_names = ", ".join(columns)
+        sql = f"INSERT INTO {table} ({col_names}) VALUES ({placeholders})"
+        if on_conflict:
+            sql += f" {on_conflict}"
+
+        with conn:
+            with conn.cursor() as cur:
+                cur.execute(sql, values)
+
+        conn.close()
+        return True
+    except Exception:
+        log.exception("Failed to insert row into %s — buffering", table)
+        try:
+            conn.close()
+        except Exception:
+            pass
+        buffer_row(table, params_dict)
+        return False
+
+
+def insert_many(
+    table: str,
+    columns: list[str],
+    rows: list[tuple],
+    *,
+    params_dicts: list[dict] | None = None,
+    on_conflict: str = "",
+) -> int:
+    """Insert multiple rows, buffering any that fail.
+
+    Returns the number of rows successfully written to the DB.
+    """
+    conn, err = _try_connect()
+    if conn is None:
+        log.warning("DB unavailable (%s) — buffering %d rows for %s", err, len(rows), table)
+        for i, row_values in enumerate(rows):
+            if params_dicts and i < len(params_dicts):
+                buffer_row(table, params_dicts[i])
+            else:
+                buffer_row(table, dict(zip(columns, row_values)))
+        return 0
+
+    try:
+        _flush_buffer(conn, table)
+    except Exception:
+        log.warning("Flush failed, continuing with current insert")
+
+    placeholders = ", ".join(["%s"] * len(columns))
+    col_names = ", ".join(columns)
+    sql = f"INSERT INTO {table} ({col_names}) VALUES ({placeholders})"
+    if on_conflict:
+        sql += f" {on_conflict}"
+
+    written = 0
+    try:
+        with conn:
+            with conn.cursor() as cur:
+                for row_values in rows:
+                    cur.execute(sql, row_values)
+                    written += 1
+        conn.close()
+        return written
+    except Exception:
+        log.exception("Failed during batch insert into %s after %d rows", table, written)
+        try:
+            conn.close()
+        except Exception:
+            pass
+        # Buffer the remaining rows
+        for i, row_values in enumerate(rows):
+            if i >= written:
+                if params_dicts and i < len(params_dicts):
+                    buffer_row(table, params_dicts[i])
+                else:
+                    buffer_row(table, dict(zip(columns, row_values)))
+        return written
+
+
+def record_heartbeat(poller_name: str, status: str = "ok", details: dict | None = None) -> None:
+    """Record a poller heartbeat with buffer status metadata."""
+    # Enrich details with buffer status
+    if details is None:
+        details = {}
+
+    tables = buffered_tables()
+    if tables:
+        buffer_info = {t: buffered_count(t) for t in tables}
+        details["buffered_rows"] = buffer_info
+        if status == "ok":
+            status = "ok_with_buffer"
+
+    conn, err = _try_connect()
+    if conn is None:
+        log.warning("DB unavailable for heartbeat (%s)", err)
+        return
+
+    try:
+        with conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    INSERT INTO poller_heartbeats (poller_name, status, details)
+                    VALUES (%s, %s, %s)
+                    """,
+                    (poller_name, status, json.dumps(details) if details else None),
+                )
+        conn.close()
+    except Exception:
+        log.exception("Failed to record heartbeat for %s", poller_name)
+        try:
+            conn.close()
+        except Exception:
+            pass

--- a/poller/poll_build.py
+++ b/poller/poll_build.py
@@ -17,9 +17,8 @@ import os
 import re
 import sys
 
-import psycopg2
-
 from browser import CryoBrowser
+from db_writer import get_db, insert_row, record_heartbeat
 
 logging.basicConfig(
     level=logging.INFO,
@@ -28,18 +27,11 @@ logging.basicConfig(
 )
 log = logging.getLogger("poll_build")
 
-DATABASE_URL = os.environ.get("DATABASE_URL", "postgresql://breacher:mycomplexpassword@db:5432/breacher")
-
 # Regex patterns for deployment fingerprinting
 DPL_PATTERN = re.compile(r"dpl=(dpl_[a-zA-Z0-9]+)")
 CHUNK_PATTERN = re.compile(r'/_next/static/chunks/([a-f0-9]{12,}\.js)')
 CSS_PATTERN = re.compile(r'/_next/static/chunks/([a-f0-9]{12,}\.css)')
 BUILD_ID_PATTERN = re.compile(r'/_next/static/([a-zA-Z0-9_-]{20,})/')
-
-
-def get_db():
-    """Get a database connection."""
-    return psycopg2.connect(DATABASE_URL)
 
 
 def get_last_build_hash() -> str | None:
@@ -160,49 +152,35 @@ def poll_build():
         summary_parts.append(f"build {build_id[:12]}")
     summary = f"Build change detected: {', '.join(summary_parts) or current_hash[:12]}"
 
-    try:
-        conn = get_db()
-        with conn:
-            with conn.cursor() as cur:
-                cur.execute(
-                    """
-                    INSERT INTO build_events
-                        (build_hash, summary, details, headers)
-                    VALUES (%s, %s, %s, %s)
-                    ON CONFLICT (build_hash) WHERE build_hash IS NOT NULL
-                    DO NOTHING
-                    """,
-                    (
-                        current_hash,
-                        summary,
-                        json.dumps(details),
-                        json.dumps(interesting_headers),
-                    ),
-                )
-        conn.close()
+    written = insert_row(
+        table="build_events",
+        columns=["build_hash", "summary", "details", "headers"],
+        values=[
+            current_hash,
+            summary,
+            json.dumps(details),
+            json.dumps(interesting_headers),
+        ],
+        params_dict={
+            "build_hash": current_hash,
+            "summary": summary,
+            "details": details,
+            "headers": interesting_headers,
+        },
+        on_conflict="ON CONFLICT (build_hash) WHERE build_hash IS NOT NULL DO NOTHING",
+    )
+    if written:
         log.info("BUILD CHANGE DETECTED — hash=%s dpl=%s (previous=%s)",
                  current_hash[:12], dpl_id or "unknown",
                  last_hash[:12] if last_hash else "none")
-    except Exception:
-        log.exception("Failed to save build event")
+    else:
+        log.warning("BUILD CHANGE DETECTED but DB unavailable — buffered (hash=%s)",
+                    current_hash[:12])
 
 
 def heartbeat(status="ok"):
     """Record poller heartbeat."""
-    try:
-        conn = get_db()
-        with conn:
-            with conn.cursor() as cur:
-                cur.execute(
-                    """
-                    INSERT INTO poller_heartbeats (poller_name, status)
-                    VALUES ('build_poller', %s)
-                    """,
-                    (status,),
-                )
-        conn.close()
-    except Exception:
-        log.exception("Failed to record heartbeat")
+    record_heartbeat("build_poller", status)
 
 
 if __name__ == "__main__":

--- a/poller/poll_index.py
+++ b/poller/poll_index.py
@@ -20,9 +20,8 @@ import re
 import sys
 from pathlib import Path
 
-import psycopg2
-
 from browser import CryoBrowser
+from db_writer import get_db, insert_row, record_heartbeat
 
 logging.basicConfig(
     level=logging.INFO,
@@ -31,7 +30,6 @@ logging.basicConfig(
 )
 log = logging.getLogger("poll_index")
 
-DATABASE_URL = os.environ.get("DATABASE_URL", "postgresql://breacher:mycomplexpassword@db:5432/breacher")
 BASE_URL = "https://cryoarchive.systems"
 
 # DAC auth credentials
@@ -48,9 +46,9 @@ INDEX_PASSWORD = os.environ.get(
 TOTAL_ENTRIES = 1200
 
 
-def get_db():
-    """Get a database connection."""
-    return psycopg2.connect(DATABASE_URL)
+def get_db_conn():
+    """Get a database connection (used for index upserts that need ON CONFLICT)."""
+    return get_db()
 
 
 def authenticate(cryo: CryoBrowser) -> bool:
@@ -255,7 +253,7 @@ def poll_index():
     log.info("Parsed %d entries (%d unlocked)", total, len(unlocked_entries))
 
     try:
-        conn = get_db()
+        conn = get_db_conn()
         with conn:
             with conn.cursor() as cur:
                 for entry in all_entries:
@@ -292,25 +290,23 @@ def poll_index():
         conn.close()
         log.info("Index entries stored successfully")
     except Exception:
-        log.exception("Failed to store index entries")
+        log.exception("Failed to store index entries — buffering snapshot")
+        # Buffer the summary snapshot so we don't lose aggregate counts
+        from buffer import buffer_row
+        type_counts = {}
+        for e in unlocked_entries:
+            t = e["entry_type"] or "UNKNOWN"
+            type_counts[t] = type_counts.get(t, 0) + 1
+        buffer_row("index_snapshots", {
+            "total_entries": total,
+            "unlocked_count": len(unlocked_entries),
+            "type_counts": type_counts,
+        })
 
 
 def heartbeat(status="ok"):
     """Record poller heartbeat."""
-    try:
-        conn = get_db()
-        with conn:
-            with conn.cursor() as cur:
-                cur.execute(
-                    """
-                    INSERT INTO poller_heartbeats (poller_name, status)
-                    VALUES ('index_poller', %s)
-                    """,
-                    (status,),
-                )
-        conn.close()
-    except Exception:
-        log.exception("Failed to record heartbeat")
+    record_heartbeat("index_poller", status)
 
 
 if __name__ == "__main__":

--- a/poller/poll_state.py
+++ b/poller/poll_state.py
@@ -9,10 +9,10 @@ import logging
 import os
 import sys
 
-import psycopg2
 import requests
 
 from browser import CryoBrowser
+from db_writer import insert_row, record_heartbeat
 
 logging.basicConfig(
     level=logging.INFO,
@@ -21,18 +21,11 @@ logging.basicConfig(
 )
 log = logging.getLogger("poll_state")
 
-DATABASE_URL = os.environ.get("DATABASE_URL", "postgresql://breacher:mycomplexpassword@db:5432/breacher")
-
 MARATHON_STEAM_APP_ID = 3065800
 STEAM_API_URL = (
     f"https://api.steampowered.com/ISteamUserStats/GetNumberOfCurrentPlayers/v1/"
     f"?appid={MARATHON_STEAM_APP_ID}"
 )
-
-
-def get_db():
-    """Get a database connection."""
-    return psycopg2.connect(DATABASE_URL)
 
 
 def poll_state(cryo: CryoBrowser):
@@ -55,29 +48,30 @@ def poll_state(cryo: CryoBrowser):
     # Flatten pages into sector states for storage
     sectors = {name: info for name, info in pages.items()}
 
-    try:
-        conn = get_db()
-        with conn:
-            with conn.cursor() as cur:
-                cur.execute(
-                    """
-                    INSERT INTO state_snapshots
-                        (kill_count, ship_date, next_update, sectors, memory_flags, raw_response)
-                    VALUES (%s, %s, %s, %s, %s, %s)
-                    """,
-                    (
-                        kill_count,
-                        ship_date,
-                        next_update,
-                        json.dumps(sectors),
-                        json.dumps(memory_flags),
-                        json.dumps(data),
-                    ),
-                )
-        conn.close()
+    written = insert_row(
+        table="state_snapshots",
+        columns=["kill_count", "ship_date", "next_update", "sectors", "memory_flags", "raw_response"],
+        values=[
+            kill_count,
+            ship_date,
+            next_update,
+            json.dumps(sectors),
+            json.dumps(memory_flags),
+            json.dumps(data),
+        ],
+        params_dict={
+            "kill_count": kill_count,
+            "ship_date": ship_date,
+            "next_update": next_update,
+            "sectors": sectors,
+            "memory_flags": memory_flags,
+            "raw_response": data,
+        },
+    )
+    if written:
         log.info("State snapshot saved (kill_count=%s)", kill_count)
-    except Exception:
-        log.exception("Failed to save state snapshot")
+    else:
+        log.warning("State snapshot buffered locally (kill_count=%s)", kill_count)
 
 
 def poll_stabilization(cryo: CryoBrowser):
@@ -97,44 +91,29 @@ def poll_stabilization(cryo: CryoBrowser):
     ]
     next_stab = min(next_stab_times) if next_stab_times else None
 
-    try:
-        conn = get_db()
-        with conn:
-            with conn.cursor() as cur:
-                cur.execute(
-                    """
-                    INSERT INTO stabilization_snapshots
-                        (cameras, next_stabilization, raw_response)
-                    VALUES (%s, %s, %s)
-                    """,
-                    (
-                        json.dumps(cameras),
-                        next_stab,
-                        json.dumps(data),
-                    ),
-                )
-        conn.close()
+    written = insert_row(
+        table="stabilization_snapshots",
+        columns=["cameras", "next_stabilization", "raw_response"],
+        values=[
+            json.dumps(cameras),
+            next_stab,
+            json.dumps(data),
+        ],
+        params_dict={
+            "cameras": cameras,
+            "next_stabilization": next_stab,
+            "raw_response": data,
+        },
+    )
+    if written:
         log.info("Stabilization snapshot saved (%d cameras)", len(cameras))
-    except Exception:
-        log.exception("Failed to save stabilization snapshot")
+    else:
+        log.warning("Stabilization snapshot buffered locally (%d cameras)", len(cameras))
 
 
 def heartbeat(status="ok", details=None):
     """Record poller heartbeat."""
-    try:
-        conn = get_db()
-        with conn:
-            with conn.cursor() as cur:
-                cur.execute(
-                    """
-                    INSERT INTO poller_heartbeats (poller_name, status, details)
-                    VALUES ('state_poller', %s, %s)
-                    """,
-                    (status, json.dumps(details) if details else None),
-                )
-        conn.close()
-    except Exception:
-        log.exception("Failed to record heartbeat")
+    record_heartbeat("state_poller", status, details)
 
 
 def poll_steam():
@@ -161,21 +140,19 @@ def poll_steam():
         log.exception("Failed to fetch Steam player count")
         return
 
-    try:
-        conn = get_db()
-        with conn:
-            with conn.cursor() as cur:
-                cur.execute(
-                    """
-                    INSERT INTO steam_snapshots (player_count, app_id)
-                    VALUES (%s, %s)
-                    """,
-                    (player_count, MARATHON_STEAM_APP_ID),
-                )
-        conn.close()
+    written = insert_row(
+        table="steam_snapshots",
+        columns=["player_count", "app_id"],
+        values=[player_count, MARATHON_STEAM_APP_ID],
+        params_dict={
+            "player_count": player_count,
+            "app_id": MARATHON_STEAM_APP_ID,
+        },
+    )
+    if written:
         log.info("Steam snapshot saved (player_count=%s)", player_count)
-    except Exception:
-        log.exception("Failed to save Steam snapshot")
+    else:
+        log.warning("Steam snapshot buffered locally (player_count=%s)", player_count)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Adds a local JSONL buffer as a safety net for all poller data when PostgreSQL is unavailable. Data is never lost during DB maintenance windows or transient outages — it's written to disk and automatically flushed on the next successful connection.

## Changes

### New modules
- **`poller/buffer.py`** — JSONL file I/O with per-table buffer files and size-capped rotation
- **`poller/db_writer.py`** — Wraps `insert_row()` / `record_heartbeat()` with try-DB-first, buffer-on-failure, flush-on-reconnect pattern

### Modified pollers
- **`poll_state.py`** — Uses `db_writer` for state, stabilization, and Steam snapshots
- **`poll_build.py`** — Uses `db_writer` for build events
- **`poll_index.py`** — Uses `db_writer` for index snapshots (index_entries still uses direct upsert due to ON CONFLICT complexity)

### Infrastructure
- **`poller/Dockerfile`** — Creates `/data/buffer` directory with correct ownership
- **`.env.example`** — Documents new env vars

## Environment Variables

| Variable | Default | Description |
|----------|---------|-------------|
| `POLLER_BUFFER_DIR` | `/data/buffer` | Directory for JSONL buffer files |
| `POLLER_BUFFER_MAX_BYTES` | `52428800` (50 MiB) | Max size per buffer file. Set to 0 for unlimited. |

## How it works

1. Poller fetches data from upstream API
2. `insert_row()` attempts DB connection
3. **If DB is up**: flush any buffered rows first, then insert the new row
4. **If DB is down**: append the row to `/data/buffer/<table>.jsonl`
5. Next successful connection auto-flushes the buffer
6. Buffer files are rotated (oldest entries dropped) when they exceed `POLLER_BUFFER_MAX_BYTES`
7. Heartbeats include buffer metadata (`buffered_rows` counts) so the status page can surface pending data

## K8s deployment note

Mount a PVC or emptyDir at `/data/buffer` in the poller pod spec to persist buffer data across pod restarts.