### PR TITLE
refactor: centralize constants and replace hardcoded hex colors

### DIFF
--- a/src/app/api/steam/history/route.ts
+++ b/src/app/api/steam/history/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { getPool } from "@/lib/db";
 import { parseLimit, parseSince, isErrorResponse } from "@/lib/validation";
 import { withCache } from "@/lib/cache";
+import { MARATHON_STEAM_APP_ID } from "@/lib/constants";
 
 /**
  * GET /api/steam/history?limit=500&since=2025-01-01T00:00:00Z
@@ -17,8 +18,6 @@ export async function GET(request: Request) {
 
   const since = parseSince(searchParams.get("since"));
   if (isErrorResponse(since)) return since;
-
-  const MARATHON_APP_ID = 3065800;
 
   const db = getPool();
   if (!db) {
@@ -40,7 +39,7 @@ export async function GET(request: Request) {
         WHERE app_id = $1 AND captured_at >= $2
         ORDER BY captured_at DESC LIMIT $3
       `;
-      params = [MARATHON_APP_ID, since, limit];
+      params = [MARATHON_STEAM_APP_ID, since, limit];
     } else {
       query = `
         SELECT captured_at, player_count
@@ -48,7 +47,7 @@ export async function GET(request: Request) {
         WHERE app_id = $1
         ORDER BY captured_at DESC LIMIT $2
       `;
-      params = [MARATHON_APP_ID, limit];
+      params = [MARATHON_STEAM_APP_ID, limit];
     }
 
     const result = await db.query(query, params);

--- a/src/app/api/steam/route.ts
+++ b/src/app/api/steam/route.ts
@@ -1,7 +1,6 @@
 import { NextResponse } from "next/server";
 import { withCache } from "@/lib/cache";
-
-const MARATHON_STEAM_APP_ID = 3065800;
+import { MARATHON_STEAM_APP_ID } from "@/lib/constants";
 
 interface SteamResponse {
   response: {

--- a/src/components/KillCountChart.tsx
+++ b/src/components/KillCountChart.tsx
@@ -3,6 +3,7 @@
 import { useMemo, useState } from "react";
 import { useKillCountData, useChartRange } from "@/hooks";
 import { URLS } from "@/lib/urls";
+import { THEME, CHART_EXTENDED } from "@/lib/constants";
 import {
   ResponsiveContainer,
   ComposedChart,
@@ -258,8 +259,8 @@ export function KillCountChart({ range: externalRange, onRangeChange }: Props = 
           >
             <defs>
               <linearGradient id="killGradient" x1="0" y1="0" x2="0" y2="1">
-                <stop offset="0%" stopColor="#FF3344" stopOpacity={0.3} />
-                <stop offset="100%" stopColor="#FF3344" stopOpacity={0.02} />
+                <stop offset="0%" stopColor={THEME.danger} stopOpacity={0.3} />
+                <stop offset="100%" stopColor={THEME.danger} stopOpacity={0.02} />
               </linearGradient>
             </defs>
             <CartesianGrid {...GRID_STYLE} />
@@ -283,7 +284,7 @@ export function KillCountChart({ range: externalRange, onRangeChange }: Props = 
                 orientation="right"
                 tickFormatter={(v) => `${v}`}
                 stroke={AXIS_STYLE.stroke}
-                tick={{ fontSize: 10, fill: "#FF6B35" }}
+                tick={{ fontSize: 10, fill: CHART_EXTENDED.killSecondary }}
                 axisLine={AXIS_STYLE.axisLine}
                 tickLine={AXIS_STYLE.tickLine}
                 width={40}
@@ -311,14 +312,14 @@ export function KillCountChart({ range: externalRange, onRangeChange }: Props = 
               type="monotone"
               dataKey="value"
               name="Kill Count"
-              stroke="#FF3344"
+              stroke={THEME.danger}
               strokeWidth={2}
               fill="url(#killGradient)"
               dot={false}
               activeDot={{
                 r: 4,
-                fill: "#FF3344",
-                stroke: "#FF3344",
+                fill: THEME.danger,
+                stroke: THEME.danger,
                 strokeWidth: 2,
               }}
             />
@@ -328,11 +329,11 @@ export function KillCountChart({ range: externalRange, onRangeChange }: Props = 
                 type="monotone"
                 dataKey="kpmSmooth"
                 name="Kills/min"
-                stroke="#FF6B35"
+                stroke={CHART_EXTENDED.killSecondary}
                 strokeWidth={1.5}
                 strokeOpacity={0.7}
                 dot={false}
-                activeDot={{ r: 3, fill: "#FF6B35", stroke: "#FF6B35" }}
+                activeDot={{ r: 3, fill: CHART_EXTENDED.killSecondary, stroke: CHART_EXTENDED.killSecondary }}
                 connectNulls
               />
             )}

--- a/src/components/PlayerCountChart.tsx
+++ b/src/components/PlayerCountChart.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo } from "react";
 import { useSteamPlayers } from "@/hooks";
+import { THEME } from "@/lib/constants";
 import {
   ResponsiveContainer,
   AreaChart,
@@ -169,8 +170,8 @@ export function PlayerCountChart({ range, onRangeChange }: Props) {
           >
             <defs>
               <linearGradient id="playerGradient" x1="0" y1="0" x2="0" y2="1">
-                <stop offset="0%" stopColor="#00FF9D" stopOpacity={0.25} />
-                <stop offset="100%" stopColor="#00FF9D" stopOpacity={0.02} />
+                <stop offset="0%" stopColor={THEME.mint} stopOpacity={0.25} />
+                <stop offset="100%" stopColor={THEME.mint} stopOpacity={0.02} />
               </linearGradient>
             </defs>
             <CartesianGrid {...GRID_STYLE} />
@@ -199,14 +200,14 @@ export function PlayerCountChart({ range, onRangeChange }: Props) {
               type="monotone"
               dataKey="valueSmooth"
               name="Players"
-              stroke="#00FF9D"
+              stroke={THEME.mint}
               strokeWidth={2}
               fill="url(#playerGradient)"
               dot={false}
               activeDot={{
                 r: 4,
-                fill: "#00FF9D",
-                stroke: "#00FF9D",
+                fill: THEME.mint,
+                stroke: THEME.mint,
                 strokeWidth: 2,
               }}
             />

--- a/src/components/StabilizationChart.tsx
+++ b/src/components/StabilizationChart.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { URLS } from "@/lib/urls";
+import { THEME, CHART_EXTENDED } from "@/lib/constants";
 import {
   ResponsiveContainer,
   LineChart,
@@ -25,15 +26,15 @@ interface StabRow {
 
 // Theme-consistent colors per camera — all meet WCAG AA on dark bg
 const CAMERA_COLORS: Record<string, string> = {
-  cargo: "#FF3344",
-  index: "#038ADF",
-  revival: "#00D4EB",
-  biostock: "#00FF9D",
-  steerage: "#FFAA00",
-  preservation: "#E0DDD2",
-  cryoHub: "#FF6B9D",
-  camera06: "#9D7AFF",
-  camera09: "#FF9D4A",
+  cargo: THEME.danger,
+  index: THEME.accent,
+  revival: THEME.accent2,
+  biostock: THEME.mint,
+  steerage: THEME.warn,
+  preservation: THEME.heading,
+  cryoHub: CHART_EXTENDED.pink,
+  camera06: CHART_EXTENDED.purple,
+  camera09: CHART_EXTENDED.warmOrange,
 };
 
 const CAMERA_LABELS: Record<string, string> = {
@@ -157,24 +158,24 @@ export function StabilizationChart() {
           >
             <CartesianGrid
               strokeDasharray="3 3"
-              stroke="#1E3A50"
+              stroke={THEME.border}
               strokeOpacity={0.5}
             />
             <XAxis
               dataKey="timestamp"
               tickFormatter={formatAxis}
-              stroke="#6E8E9E"
-              tick={{ fontSize: 10, fill: "#6E8E9E" }}
-              axisLine={{ stroke: "#1E3A50" }}
-              tickLine={{ stroke: "#1E3A50" }}
+              stroke={THEME.dim}
+              tick={{ fontSize: 10, fill: THEME.dim }}
+              axisLine={{ stroke: THEME.border }}
+              tickLine={{ stroke: THEME.border }}
               interval="preserveStartEnd"
               minTickGap={60}
             />
             <YAxis
-              stroke="#6E8E9E"
-              tick={{ fontSize: 10, fill: "#6E8E9E" }}
-              axisLine={{ stroke: "#1E3A50" }}
-              tickLine={{ stroke: "#1E3A50" }}
+              stroke={THEME.dim}
+              tick={{ fontSize: 10, fill: THEME.dim }}
+              axisLine={{ stroke: THEME.border }}
+              tickLine={{ stroke: THEME.border }}
               width={40}
               domain={[0, 100]}
               tickFormatter={(v) => `${v}%`}
@@ -186,14 +187,14 @@ export function StabilizationChart() {
                 CAMERA_LABELS[name as string] ?? name,
               ]}
               contentStyle={{
-                backgroundColor: "#0C1A22",
-                border: "1px solid #1E3A50",
+                backgroundColor: THEME.bg,
+                border: `1px solid ${THEME.border}`,
                 borderRadius: 0,
                 fontSize: 12,
-                color: "#8AACB8",
+                color: THEME.text,
               }}
               labelStyle={{
-                color: "#00D4EB",
+                color: THEME.accent2,
                 fontFamily: "var(--font-display)",
                 fontSize: 11,
                 letterSpacing: "1px",
@@ -201,14 +202,14 @@ export function StabilizationChart() {
             />
             <Legend
               formatter={(value) => CAMERA_LABELS[value] ?? value}
-              wrapperStyle={{ fontSize: 10, color: "#8AACB8" }}
+              wrapperStyle={{ fontSize: 10, color: THEME.text }}
             />
             {cameras.map((cam) => (
               <Line
                 key={cam}
                 type="monotone"
                 dataKey={cam}
-                stroke={CAMERA_COLORS[cam] ?? "#8AACB8"}
+                stroke={CAMERA_COLORS[cam] ?? THEME.text}
                 strokeWidth={1.5}
                 dot={false}
                 activeDot={{ r: 3 }}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -56,8 +56,7 @@ export async function fetchStabilization(): Promise<Record<
 }
 
 // ---- Steam ----
-
-const MARATHON_STEAM_APP_ID = 3065800;
+import { MARATHON_STEAM_APP_ID } from "@/lib/constants";
 
 interface SteamPlayerResponse {
   response: {

--- a/src/lib/chart-utils.ts
+++ b/src/lib/chart-utils.ts
@@ -184,6 +184,8 @@ export function clampedDomain(
   ];
 }
 
+import { THEME } from "@/lib/constants";
+
 /* ------------------------------------------------------------------ */
 /*  Shared chart style tokens                                          */
 /* ------------------------------------------------------------------ */
@@ -191,14 +193,14 @@ export function clampedDomain(
 /** Tooltip content style matching the cryo design language. */
 export const TOOLTIP_STYLE = {
   contentStyle: {
-    backgroundColor: "#0C1A22", // --color-cryo-bg
-    border: "1px solid #1E3A50", // --color-cryo-border
+    backgroundColor: THEME.bg,
+    border: `1px solid ${THEME.border}`,
     borderRadius: 0,
     fontSize: 12,
-    color: "#8AACB8", // --color-cryo-body
+    color: THEME.text,
   },
   labelStyle: {
-    color: "#00D4EB", // --color-cryo-accent
+    color: THEME.accent2,
     fontFamily: "var(--font-display)",
     fontSize: 11,
     letterSpacing: "1px",
@@ -207,15 +209,15 @@ export const TOOLTIP_STYLE = {
 
 /** Common axis styling. */
 export const AXIS_STYLE = {
-  stroke: "#6E8E9E", // --color-cryo-dim
-  tick: { fontSize: 10, fill: "#6E8E9E" },
-  axisLine: { stroke: "#1E3A50" }, // --color-cryo-border
-  tickLine: { stroke: "#1E3A50" },
+  stroke: THEME.dim,
+  tick: { fontSize: 10, fill: THEME.dim },
+  axisLine: { stroke: THEME.border },
+  tickLine: { stroke: THEME.border },
 } as const;
 
 /** Grid styling. */
 export const GRID_STYLE = {
   strokeDasharray: "3 3",
-  stroke: "#1E3A50", // --color-cryo-border
+  stroke: THEME.border,
   strokeOpacity: 0.5,
 } as const;

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,0 +1,59 @@
+// ============================================================
+// Centralized constants — single source of truth for values
+// shared across the application.
+//
+// Update values here instead of hunting through components.
+// ============================================================
+
+/** Marathon's Steam Application ID. */
+export const MARATHON_STEAM_APP_ID = 3065800;
+
+// ============================================================
+// Theme color tokens for JS contexts (Recharts, canvas, etc.)
+//
+// These MUST stay in sync with the CSS custom properties in
+// globals.css.  Recharts SVG props require literal hex strings,
+// so we mirror the design-system palette here.
+// ============================================================
+
+export const THEME = {
+  /** Primary accent — headings, links, glows */
+  accent: "#038ADF", // --color-cryo-accent
+  /** Secondary accent — system response */
+  accent2: "#00D4EB", // --color-cryo-accent2
+  /** Tertiary accent — success, status */
+  mint: "#00FF9D", // --color-mint
+  /** Warning states */
+  warn: "#FFAA00", // --color-cryo-warn
+  /** Errors, kill count, alerts */
+  danger: "#FF3344", // --color-cryo-danger
+  /** Page background */
+  bg: "#031A22", // --color-cryo-bg
+  /** Card/panel backgrounds */
+  panel: "#0A2A35", // --color-cryo-panel
+  /** Elevated card backgrounds */
+  card: "#12384A", // --color-void-card
+  /** Panel borders, dividers */
+  border: "#1A4660", // --color-cryo-border
+  /** Main body text */
+  text: "#8AACB8", // --color-cryo-text
+  /** Secondary/meta text */
+  dim: "#5A7A8A", // --color-cryo-dim
+  /** Headings, emphasis */
+  heading: "#E0DDD2", // --color-text-heading
+} as const;
+
+/**
+ * Extended palette for chart series that need more colors than
+ * the core design system provides (e.g. 9 camera feeds).
+ */
+export const CHART_EXTENDED = {
+  /** Kill count secondary line / projection */
+  killSecondary: "#FF6B35",
+  /** Stabilization camera: Cryo Hub */
+  pink: "#FF6B9D",
+  /** Stabilization camera: Camera 06 */
+  purple: "#9D7AFF",
+  /** Stabilization camera: Camera 09 */
+  warmOrange: "#FF9D4A",
+} as const;


### PR DESCRIPTION
## Summary

Centralizes shared constants and eliminates hardcoded hex colors across the codebase.

### Changes

**New file: `src/lib/constants.ts`**
- `MARATHON_STEAM_APP_ID` — single source of truth (was duplicated in 3 files with inconsistent naming)
- `THEME` — design system color palette mirrored for JS contexts (Recharts SVG props need hex strings)
- `CHART_EXTENDED` — additional chart series colors not in the core palette (camera feeds, kill projections)

**Updated files (8):**
- `src/lib/api.ts` — imports `MARATHON_STEAM_APP_ID`
- `src/app/api/steam/route.ts` — imports `MARATHON_STEAM_APP_ID`
- `src/app/api/steam/history/route.ts` — imports `MARATHON_STEAM_APP_ID` (was `MARATHON_APP_ID` — inconsistent naming)
- `src/lib/chart-utils.ts` — all `TOOLTIP_STYLE`, `AXIS_STYLE`, `GRID_STYLE` use `THEME` constants
- `src/components/StabilizationChart.tsx` — 24 hex replacements (`CAMERA_COLORS` + chart styling)
- `src/components/KillCountChart.tsx` — 9 hex replacements (gradients, lines, dots)
- `src/components/PlayerCountChart.tsx` — 5 hex replacements (gradients, lines, dots)

**Color drift fixes:** Three hex values that had drifted from the CSS variables (`#0C1A22`, `#1E3A50`, `#6E8E9E`) now use the correct design-system values.

### Validation
- `npm run lint` ✅
- `npm run build` ✅
- No visual changes — THEME constants mirror the exact CSS variable values

Closes #90, closes #91