### PR TITLE
chore: v0.6.0 release prep — version, CHANGELOG, README, optimizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-03-20
+
+### Added
+
+- **Poller JSON buffer** — pollers write to a local JSON buffer when the database is unavailable; `db_writer` flushes buffered data on reconnect with configurable `POLLER_BUFFER_MAX_BYTES` (default 50 MiB) ([#86](https://github.com/breachers-of-tomorrow/breacher-net/pull/86))
+- **Steam player count tracking** — `/api/steam` and `/api/steam/history` endpoints serve live and historical Steam player data; `poll_steam.py` collects snapshots every 5 minutes ([#87](https://github.com/breachers-of-tomorrow/breacher-net/issues/87))
+- **Player count chart** — `PlayerCountChart` component on the Marathon metrics page ([#87](https://github.com/breachers-of-tomorrow/breacher-net/issues/87))
+- **Kill analytics panel** — `KillAnalytics` component correlating kill rate with player count ([#87](https://github.com/breachers-of-tomorrow/breacher-net/issues/87))
+- **Homepage JSON-LD** — `WebSite` structured data for search engine rich results ([#89](https://github.com/breachers-of-tomorrow/breacher-net/issues/89))
+- **`steam_snapshots` freshness** in status API — status page now monitors Steam data staleness ([#88](https://github.com/breachers-of-tomorrow/breacher-net/issues/88))
+
+### Changed
+
+- **Community pivot** — site rebranded from ARG-only tracker to "The Breacher Network" community hub; new homepage, restructured navigation, dedicated `/marathon` metrics page ([#75](https://github.com/breachers-of-tomorrow/breacher-net/issues/75))
+- **Chart hooks extracted** — `useKillCountData`, `useSteamPlayers`, `useChartRange` hooks in `src/hooks/` replace inline data fetching ([#81](https://github.com/breachers-of-tomorrow/breacher-net/pull/81))
+- **Centralized constants** — `MARATHON_STEAM_APP_ID` and chart theme colors defined once in `src/lib/constants.ts`; no more hardcoded hex in chart configs ([#90](https://github.com/breachers-of-tomorrow/breacher-net/issues/90), [#91](https://github.com/breachers-of-tomorrow/breacher-net/issues/91))
+- **Homepage semantic headings** — section titles changed from `<div>` to `<h2>` for SEO and accessibility ([#89](https://github.com/breachers-of-tomorrow/breacher-net/issues/89))
+- **Status page refactored** — queries database directly instead of self-fetching own API over HTTP ([#92](https://github.com/breachers-of-tomorrow/breacher-net/issues/92))
+
+### Fixed
+
+- **API docs accuracy** — corrected `/api/health` response shape, added missing `/api/steam` and `/api/steam/history` docs, updated rate limiting section to reflect actual sliding window implementation ([#87](https://github.com/breachers-of-tomorrow/breacher-net/issues/87))
+- **Removed client-side kill count dedup** — SQL `lag()` window function already handles deduplication; removed redundant JS pass ([#95](https://github.com/breachers-of-tomorrow/breacher-net/issues/95))
+- **Sitemap `lastModified`** — uses build-time date instead of `new Date()` on every request ([#95](https://github.com/breachers-of-tomorrow/breacher-net/issues/95))
+- **Poller crontab** — added missing `poll_index.py` schedule ([#94](https://github.com/breachers-of-tomorrow/breacher-net/issues/94))
+
 ## [0.5.0] - 2026-03-15
 
 ### Added
@@ -143,7 +169,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Migrated from static HTML/Python to Next.js App Router architecture
 - Replaced CSV data storage design with PostgreSQL
 
-[Unreleased]: https://github.com/breachers-of-tomorrow/breacher-net/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/breachers-of-tomorrow/breacher-net/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/breachers-of-tomorrow/breacher-net/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/breachers-of-tomorrow/breacher-net/compare/v0.4.1...v0.5.0
 [0.4.1]: https://github.com/breachers-of-tomorrow/breacher-net/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/breachers-of-tomorrow/breacher-net/compare/v0.3.0...v0.4.0

--- a/README.md
+++ b/README.md
@@ -50,32 +50,37 @@ The app works without a database — it fetches directly from the cryoarchive.sy
 graph TD
     subgraph "breacher.net"
         App["Next.js App\n:3000"]
-        StatePoller["State Poller\n(every 15m)"]
+        StatePoller["State Poller\n(every 5m)"]
         BuildPoller["Build Poller\n(every 60s)"]
         IndexPoller["Index Poller\n(every 15m)"]
+        SteamPoller["Steam Poller\n(every 5m)"]
         DB["PostgreSQL 17\n(Patroni HA)"]
     end
 
     API["cryoarchive.systems"]
+    Steam["Steam Web API"]
     DAC["DAC Auth File\n(K8s Secret)"]
 
     App -- "server proxy" --> API
     StatePoller -- "GET /api/public/state" --> API
     BuildPoller -- "HEAD + chunk diff" --> API
     IndexPoller -- "DAC auth + /indx" --> API
+    SteamPoller -- "GetNumberOfCurrentPlayers" --> Steam
     IndexPoller -- "mount" --> DAC
     App -- "DAC auth (fallback)" --> DAC
     StatePoller -- "write" --> DB
     BuildPoller -- "write" --> DB
     IndexPoller -- "write" --> DB
+    SteamPoller -- "write" --> DB
     App -- "read" --> DB
 ```
 
 - **Next.js App** — Server-rendered React with App Router. Proxies live data requests to cryoarchive.systems server-side (avoids CORS). Serves historical data from PostgreSQL.
-- **State Poller** — Python CronJob. Snapshots kill count, sector states, and ship date every 15 minutes.
+- **State Poller** — Python CronJob. Snapshots kill count, sector states, stabilization levels, and ship date every 5 minutes.
 - **Build Poller** — Python CronJob. Checks for deployment changes every 60 seconds via chunk/asset fingerprinting.
-- **Index Poller** — Python CronJob. Authenticates via DAC + password, extracts and stores all 1200+ index entries with full content.
-- **PostgreSQL** — Stores state snapshots, stabilization history, build events, index entries, and session cookies.
+- **Index Poller** — Python CronJob. Authenticates via DAC + password, extracts and stores all 1200+ index entries with full content every 15 minutes.
+- **Steam Poller** — Python CronJob. Collects Marathon player count from Steam Web API every 5 minutes.
+- **PostgreSQL** — Stores state snapshots, stabilization history, steam player counts, build events, index entries, and session cookies.
 
 ## Environment Variables
 
@@ -83,6 +88,7 @@ graph TD
 |----------|----------|-------------|
 | `DATABASE_URL` | For DB features | PostgreSQL connection string (e.g., `postgresql://user:pass@host:5432/db`) |
 | `CRYO_DAC_PATH` | For index features | Path to mounted DAC authentication file (see DAC Auth below) |
+| `POLLER_BUFFER_MAX_BYTES` | No | Max size of JSON buffer when DB is unavailable (default: 52428800 / 50 MiB) |
 
 ## DAC Authentication
 
@@ -122,25 +128,57 @@ export CRYO_DAC_PATH=/path/to/your-dac-file.png
 
 ```
 src/
-├── app/                    # Next.js App Router pages
-│   ├── api/                # API routes (health, history, builds, proxy)
-│   │   ├── state/          # State history + live proxy
-│   │   ├── stabilization/  # Stabilization history + live proxy
-│   │   ├── builds/         # Build event history
-│   │   └── index-entries/  # Index entries + scrape fallback
-│   ├── cryoarchive/        # ARG tracking pages
-│   │   ├── cameras/        # Camera stabilization monitoring
-│   │   ├── changes/        # Build change tracker
-│   │   ├── index/          # Cryoarchive index archive
-│   │   └── maps/           # Terminal maps
-│   └── page.tsx            # Landing page
-├── components/             # Shared React components
-│   ├── KillCountChart.tsx  # Historical kill count chart
-│   ├── StabilizationChart.tsx  # Camera stabilization chart
-│   └── Navigation.tsx      # Site navigation
-└── lib/                    # Utilities (API client, DB, types, formatting)
-poller/                     # Python poller service
-db/                         # Database schema
+├── app/                          # Next.js App Router pages
+│   ├── api/                      # API routes
+│   │   ├── builds/               # Build event history + latest
+│   │   ├── health/               # Health check
+│   │   ├── index-entries/        # Index entries
+│   │   ├── stabilization/        # Stabilization history + latest
+│   │   ├── state/                # State history + latest
+│   │   ├── status/               # Infrastructure status + freshness
+│   │   └── steam/                # Steam player count + history
+│   ├── about/                    # About page
+│   ├── api-docs/                 # API documentation page
+│   ├── community/                # Community resources page
+│   ├── contribute/               # Contribution guide page
+│   ├── cryoarchive/              # ARG tracking pages
+│   │   ├── cameras/              # Camera stabilization monitoring
+│   │   ├── changes/              # Build change tracker
+│   │   ├── index/                # Cryoarchive index archive
+│   │   └── maps/                 # Terminal maps
+│   ├── marathon/                 # Marathon metrics (charts, analytics)
+│   ├── status/                   # Status page
+│   └── page.tsx                  # Landing page (The Breacher Network)
+├── components/                   # Shared React components
+│   ├── KillAnalytics.tsx         # Kill rate / player correlation panel
+│   ├── KillCountChart.tsx        # Historical kill count chart
+│   ├── KillCountEta.tsx          # Kill count target ETA estimator
+│   ├── Navigation.tsx            # Site navigation
+│   ├── PlayerCountChart.tsx      # Steam player count chart
+│   └── StabilizationChart.tsx    # Camera stabilization chart
+├── hooks/                        # Custom React hooks
+│   ├── useChartRange.ts          # Time range picker state
+│   ├── useKillCountData.ts       # Kill count data fetcher
+│   └── useSteamPlayers.ts        # Steam player data fetcher
+└── lib/                          # Utilities
+    ├── api.ts                    # API client helpers
+    ├── cache.ts                  # Cache-Control header presets
+    ├── chart-utils.ts            # Chart formatting, colors, time ranges
+    ├── constants.ts              # Shared constants (Steam App ID, theme)
+    ├── db.ts                     # PostgreSQL connection pool
+    ├── format.ts                 # Number/date formatting
+    ├── rate-limit.ts             # Sliding window rate limiter
+    ├── types.ts                  # TypeScript type definitions
+    ├── urls.ts                   # External URL constants
+    └── validation.ts             # API input validation
+poller/                           # Python poller service
+├── buffer.py                     # JSON buffer for DB outage resilience
+├── db_writer.py                  # Buffered database writer
+├── poll_build.py                 # Build change detection (every 60s)
+├── poll_index.py                 # Index archive snapshots (every 15m)
+├── poll_state.py                 # State + stabilization (every 5m)
+└── poll_steam.py                 # Steam player count (every 5m)
+db/                               # Database schema (7 tables)
 ```
 
 ## Contributing

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "breacher-net",
-  "version": "0.1.0",
+  "version": "0.6.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/poller/crontab
+++ b/poller/crontab
@@ -1,5 +1,11 @@
 # State + stabilization snapshot every 5 minutes
 */5 * * * * /usr/local/bin/python /app/poll_state.py
 
+# Steam player count every 5 minutes
+*/5 * * * * /usr/local/bin/python /app/poll_steam.py
+
+# Index archive snapshot every 15 minutes
+*/15 * * * * /usr/local/bin/python /app/poll_index.py
+
 # Build change detection every 60 seconds
 * * * * * /usr/local/bin/python /app/poll_build.py

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,9 +1,13 @@
 import type { MetadataRoute } from "next";
 import { SITE_URL } from "@/lib/urls";
 
+// Use a fixed build-time date so crawlers see stable lastModified values
+// instead of "now" on every request (wastes crawl budget).
+const BUILD_DATE = new Date();
+
 export default function sitemap(): MetadataRoute.Sitemap {
   const baseUrl = SITE_URL;
-  const now = new Date();
+  const now = BUILD_DATE;
 
   return [
     {

--- a/src/hooks/useKillCountData.ts
+++ b/src/hooks/useKillCountData.ts
@@ -20,9 +20,10 @@ const HISTORY_API = "/api/state/history?limit=1000";
 /**
  * Fetch kill-count history from the DB-backed API.
  *
- * Returns sorted rows and a deduplicated subset (consecutive
- * identical kill_counts collapsed).  Every consumer gets the same
- * data without re-fetching.
+ * Returns sorted rows already deduplicated server-side (the SQL uses
+ * a `lag()` window function to collapse consecutive identical
+ * kill_counts).  `deduped` is an alias for `rows` kept for backward
+ * compatibility.
  *
  * @returns `{ rows, deduped, loading, error }`
  */
@@ -53,23 +54,12 @@ export function useKillCountData() {
             new Date(b.captured_at).getTime(),
         );
 
-        // Deduplicate consecutive identical kill_counts.
-        // The game state updates every ~15 min but we poll every ~5 min,
-        // so ~2/3 of rows are duplicates.
-        const unique: KillCountRow[] = [];
-        for (const r of sorted) {
-          const kc = Number(r.kill_count);
-          if (
-            unique.length === 0 ||
-            Number(unique[unique.length - 1].kill_count) !== kc
-          ) {
-            unique.push(r);
-          }
-        }
+        // Server-side SQL already deduplicates via lag() window function,
+        // so sorted data is ready to use directly.
 
         if (!cancelled) {
           setRows(sorted);
-          setDeduped(unique);
+          setDeduped(sorted);
         }
       } catch (err) {
         if (!cancelled) {


### PR DESCRIPTION
## Changes

- **package.json** version bumped to `0.6.0` (#93)
- **CHANGELOG.md** — full v0.6.0 section documenting all changes since v0.5.0
- **README.md** — updated project structure, architecture diagram (added Steam Poller), env var table (#94)
- **poller/crontab** — added `poll_index.py` (every 15m) and `poll_steam.py` (every 5m) schedules (#94)
- **sitemap.ts** — uses build-time date instead of `new Date()` per request (#95)
- **useKillCountData** — removed redundant client-side dedup (SQL `lag()` already handles it) (#95)

## Validation
- `npm run lint` ✅
- `npm run test` ✅ (73/73)
- `npm run build` ✅

Closes #93, closes #94, closes #95