### PR TITLE
fix(charts): filter anomalous kill count decreases

### DIFF
--- a/src/app/api/state/history/route.ts
+++ b/src/app/api/state/history/route.ts
@@ -37,6 +37,7 @@ export async function GET(request: Request) {
         WHERE kill_count IS NOT NULL
       ) sub
       WHERE kill_count IS DISTINCT FROM prev_kc
+        AND (prev_kc IS NULL OR kill_count >= prev_kc)
     `;
     const params: (string | number)[] = [];
 

--- a/src/hooks/useKillCountData.ts
+++ b/src/hooks/useKillCountData.ts
@@ -54,12 +54,22 @@ export function useKillCountData() {
             new Date(b.captured_at).getTime(),
         );
 
-        // Server-side SQL already deduplicates via lag() window function,
-        // so sorted data is ready to use directly.
+        // Enforce monotonic increase: kill count is a cumulative counter
+        // and should never decrease.  Stale upstream data can cause dips
+        // that the SQL filter normally catches; this is a client safety net.
+        const monotonic: KillCountRow[] = [];
+        let maxKc = -Infinity;
+        for (const row of sorted) {
+          const kc = Number(row.kill_count);
+          if (kc >= maxKc) {
+            monotonic.push(row);
+            maxKc = kc;
+          }
+        }
 
         if (!cancelled) {
-          setRows(sorted);
-          setDeduped(sorted);
+          setRows(monotonic);
+          setDeduped(monotonic);
         }
       } catch (err) {
         if (!cancelled) {


### PR DESCRIPTION
## Problem

The kill count chart nosedives at the right edge. The cryoarchive API occasionally serves stale/cached responses with lower `kill_count` values than the current count. The SQL dedup filter (`IS DISTINCT FROM prev_kc`) correctly identifies these as "different" rows but doesn't catch that a cumulative counter went backwards.

**Evidence from live data:**
- `2026-03-20T16:46` → kill_count: **349,902,627**
- `2026-03-20T17:01` → kill_count: **334,236,645** (dropped 15.7M!)
- The bad entry's `next_update` field pointed to the **previous day**, confirming stale upstream data.

## Fix

Two layers of defense:

### 1. SQL monotonic filter (server-side)
Added `AND (prev_kc IS NULL OR kill_count >= prev_kc)` to the state history query. Rows where kill count decreased from the prior snapshot are excluded before reaching the client.

### 2. Client-side safety net
`useKillCountData` hook now enforces monotonic increase after sorting — any row where `kill_count` drops below the running maximum is discarded. This catches edge cases the SQL filter might miss (e.g., if the first snapshot ever recorded has a higher value than a later one due to data migration).

## Testing
- ✅ `npm run lint` — clean
- ✅ `npm test` — 73/73 pass
- ✅ `npm run build` — success