### PR TITLE
feat(nav): grouped dropdown menus + page card dedup

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { URLS } from "@/lib/urls";
-import { SITE_URL } from "@/lib/urls";
+import { URLS, SITE_URL } from "@/lib/urls";
 
 export const metadata: Metadata = {
   title: "About",
@@ -64,80 +63,6 @@ export default function AboutPage() {
         </div>
       </section>
 
-      {/* Get Started */}
-      <section className="mb-12">
-        <div className="section-title">GET STARTED</div>
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-          <Step
-            number="01"
-            title="JOIN THE DISCORD"
-            description="The heart of the community. Key channels: #general, #announcements, #lfg-breach-protocol"
-            href={URLS.discord}
-            cta="JOIN DISCORD"
-          />
-          <Step
-            number="02"
-            title="CHECK THE DASHBOARD"
-            description="Live kill count, sector states, camera stabilization, site changes, and terminal maps"
-            href="/cryoarchive"
-            cta="OPEN DASHBOARD"
-            internal
-          />
-          <Step
-            number="03"
-            title="READ THE RESEARCH"
-            description="Community objectives, historical data from Winnower Garden, and Tau Ceti resources"
-            href={URLS.communityDoc}
-            cta="COMMUNITY DOC"
-          />
-          <Step
-            number="04"
-            title="CONTRIBUTE"
-            description="From ARG research to code contributions — there's a path for every skill set"
-            href="/community"
-            cta="SEE HOW"
-            internal
-          />
-        </div>
-      </section>
-
-      {/* Ways to Contribute */}
-      <section className="mb-12">
-        <div className="section-title">WAYS TO CONTRIBUTE</div>
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-          <ContributionPath
-            icon="🔍"
-            title="ARG RESEARCH"
-            description="Track cryoarchive changes, document findings, share theories in Discord thinking pods"
-          />
-          <ContributionPath
-            icon="💻"
-            title="CODE & TOOLS"
-            description="Contribute to breacher.net (Next.js/React/TypeScript), pollers (Python), or build new tools"
-          />
-          <ContributionPath
-            icon="✍️"
-            title="WRITING & DOCS"
-            description="Help migrate community research to the wiki, write guides, document lore and theories"
-          />
-          <ContributionPath
-            icon="🎨"
-            title="DESIGN & BRANDING"
-            description="Visual identity, social media graphics, Discord assets, community brand development"
-          />
-          <ContributionPath
-            icon="🤝"
-            title="COMMUNITY BUILDING"
-            description="Welcome new members, organize events, moderate channels, build connections"
-          />
-          <ContributionPath
-            icon="📊"
-            title="DATA & ANALYSIS"
-            description="Track sector data, analyze kill count trends, monitor stabilization patterns"
-          />
-        </div>
-      </section>
-
       {/* Community Structure */}
       <section className="mb-12">
         <div className="section-title">COMMUNITY STRUCTURE</div>
@@ -158,138 +83,21 @@ export default function AboutPage() {
         </div>
       </section>
 
-      {/* Credits */}
-      <section className="mb-12">
-        <div className="section-title">CREDITS</div>
-        <div className="cryo-panel p-6 sm:p-8 space-y-3">
-          <CreditLine
-            label="ORIGINAL TRACKER"
-            name="CrowdTypical"
-            href={URLS.crowdTypical}
-          />
-          <CreditLine
-            label="HISTORICAL DATA"
-            name="Winnower Garden"
-            href={URLS.winnower}
-          />
-          <CreditLine
-            label="COMMUNITY"
-            name="Breachers of Tomorrow"
-            href={URLS.github}
-          />
-        </div>
-      </section>
-
-      {/* Quick Links */}
+      {/* Next steps */}
       <div className="flex flex-wrap gap-4 justify-center">
         <Link
-          href="/community"
+          href="/contribute"
           className="font-[var(--font-display)] text-xs tracking-[3px] uppercase px-6 py-3 bg-accent/10 border border-accent text-accent hover:bg-accent/20 transition-colors no-underline"
+        >
+          GET INVOLVED →
+        </Link>
+        <Link
+          href="/community"
+          className="font-[var(--font-display)] text-xs tracking-[3px] uppercase px-6 py-3 bg-panel border border-border text-dim hover:text-foreground hover:border-accent transition-colors no-underline"
         >
           COMMUNITY RESOURCES →
         </Link>
-        <Link
-          href="/cryoarchive"
-          className="font-[var(--font-display)] text-xs tracking-[3px] uppercase px-6 py-3 bg-panel border border-border text-dim hover:text-foreground hover:border-accent transition-colors no-underline"
-        >
-          OPEN DASHBOARD →
-        </Link>
       </div>
     </main>
-  );
-}
-
-function Step({
-  number,
-  title,
-  description,
-  href,
-  cta,
-  internal,
-}: {
-  number: string;
-  title: string;
-  description: string;
-  href: string;
-  cta: string;
-  internal?: boolean;
-}) {
-  const Component = internal ? Link : "a";
-  const externalProps = internal
-    ? {}
-    : { target: "_blank", rel: "noopener noreferrer" };
-
-  return (
-    <Component
-      href={href}
-      {...externalProps}
-      className="cryo-panel p-6 hover:border-accent transition-colors no-underline group"
-    >
-      <div className="flex items-start gap-4">
-        <div className="font-[var(--font-display)] text-2xl font-black text-accent/20 shrink-0">
-          {number}
-        </div>
-        <div className="flex-1">
-          <div className="font-[var(--font-display)] text-xs tracking-[3px] text-accent group-hover:glow-accent mb-2">
-            {title}
-          </div>
-          <p className="text-dim text-sm leading-relaxed mb-3">
-            {description}
-          </p>
-          <div className="font-[var(--font-display)] text-[0.6rem] tracking-[2px] text-accent2 group-hover:glow-accent2">
-            {cta} →
-          </div>
-        </div>
-      </div>
-    </Component>
-  );
-}
-
-function ContributionPath({
-  icon,
-  title,
-  description,
-}: {
-  icon: string;
-  title: string;
-  description: string;
-}) {
-  return (
-    <div className="cryo-panel p-5">
-      <div className="text-2xl mb-3" aria-hidden="true">
-        {icon}
-      </div>
-      <div className="font-[var(--font-display)] text-xs tracking-[3px] text-accent mb-2">
-        {title}
-      </div>
-      <p className="text-dim text-sm leading-relaxed">{description}</p>
-    </div>
-  );
-}
-
-function CreditLine({
-  label,
-  name,
-  href,
-}: {
-  label: string;
-  name: string;
-  href: string;
-}) {
-  return (
-    <div className="flex items-center gap-3 text-sm">
-      <span className="font-[var(--font-display)] text-[0.6rem] tracking-[3px] text-dim shrink-0">
-        {label}
-      </span>
-      <span className="h-px flex-1 bg-border" />
-      <a
-        href={href}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="text-accent hover:glow-accent"
-      >
-        {name}
-      </a>
-    </div>
   );
 }

--- a/src/app/contribute/page.tsx
+++ b/src/app/contribute/page.tsx
@@ -186,60 +186,20 @@ export default function ContributePage() {
         </div>
       </section>
 
-      {/* Tech Stack (for developers) */}
+      {/* Developer note */}
       <section className="mb-12">
-        <div className="section-title">FOR DEVELOPERS</div>
-        <div className="cryo-panel p-6 sm:p-8">
-          <p className="text-dim text-sm leading-relaxed mb-4">
-            breacher.net is fully open source. Here&apos;s the stack:
-          </p>
-          <div className="grid grid-cols-2 sm:grid-cols-3 gap-3 mb-6">
-            {[
-              { label: "Framework", value: "Next.js 16" },
-              { label: "UI", value: "React 19" },
-              { label: "Language", value: "TypeScript 5" },
-              { label: "Styling", value: "Tailwind CSS 4" },
-              { label: "Database", value: "PostgreSQL" },
-              { label: "Poller", value: "Python" },
-            ].map((item) => (
-              <div key={item.label} className="bg-background/50 border border-border/50 px-3 py-2">
-                <div className="font-[var(--font-display)] text-[0.55rem] tracking-[2px] text-dim mb-0.5">
-                  {item.label.toUpperCase()}
-                </div>
-                <div className="text-accent2 text-xs">{item.value}</div>
-              </div>
-            ))}
-          </div>
-          <div className="flex flex-wrap gap-4">
-            <a
-              href={URLS.breacherNetRepo}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="font-[var(--font-display)] text-[0.6rem] tracking-[2px] uppercase px-4 py-2.5 bg-accent/10 border border-accent text-accent hover:bg-accent/20 transition-colors no-underline inline-flex items-center gap-2"
-            >
-              <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                <path
-                  fillRule="evenodd"
-                  d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"
-                  clipRule="evenodd"
-                />
-              </svg>
-              VIEW SOURCE
-            </a>
-            <a
-              href={`${URLS.breacherNetRepo}/issues`}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="font-[var(--font-display)] text-[0.6rem] tracking-[2px] uppercase px-4 py-2.5 bg-panel border border-border text-dim hover:text-foreground hover:border-accent transition-colors no-underline"
-            >
-              OPEN ISSUES
-            </a>
-            <Link
-              href="/api-docs"
-              className="font-[var(--font-display)] text-[0.6rem] tracking-[2px] uppercase px-4 py-2.5 bg-panel border border-border text-dim hover:text-foreground hover:border-accent transition-colors no-underline"
-            >
-              API DOCS
-            </Link>
+        <div className="cryo-panel p-6 sm:p-8 flex flex-col sm:flex-row items-start sm:items-center gap-4">
+          <div className="text-2xl shrink-0" aria-hidden="true">💻</div>
+          <div className="flex-1">
+            <p className="text-dim text-sm leading-relaxed">
+              <strong className="text-accent">Developers</strong> — breacher.net is fully
+              open source (Next.js 16, React 19, TypeScript 5, Tailwind 4, PostgreSQL).
+              Check out the{" "}
+              <Link href="/community" className="text-accent2 hover:glow-accent2">
+                Community Resources
+              </Link>{" "}
+              page for source code, open issues, and the full tech stack.
+            </p>
           </div>
         </div>
       </section>

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -2,8 +2,12 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { URLS } from "@/lib/urls";
+
+/* ------------------------------------------------------------------ */
+/*  Types & data                                                       */
+/* ------------------------------------------------------------------ */
 
 interface NavLink {
   href: string;
@@ -11,17 +15,24 @@ interface NavLink {
   external?: boolean;
 }
 
-interface NavSection {
+interface NavGroup {
   label: string;
-  links: NavLink[];
+  icon?: string;
+  href?: string;
+  links?: NavLink[];
 }
 
-const NAV_SECTIONS: NavSection[] = [
+const NAV_GROUPS: NavGroup[] = [
   {
-    label: "BREACHER NET",
+    label: "HOME",
+    href: "/",
+    icon: "M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-4 0a1 1 0 01-1-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 01-1 1h-2z",
+  },
+  {
+    label: "COMMUNITY",
     links: [
       { href: "/about", label: "About" },
-      { href: "/community", label: "Community" },
+      { href: "/community", label: "Resources" },
       { href: "/contribute", label: "Contribute" },
       { href: URLS.wiki, label: "Wiki", external: true },
       { href: URLS.discord, label: "Discord", external: true },
@@ -49,25 +60,198 @@ const NAV_SECTIONS: NavSection[] = [
     links: [
       { href: "/api-docs", label: "API Docs" },
       { href: "/status", label: "Status" },
-      {
-        href: URLS.communityDoc,
-        label: "Community Doc",
-        external: true,
-      },
+      { href: URLS.communityDoc, label: "Community Doc", external: true },
       { href: URLS.winnower, label: "Winnower", external: true },
       { href: URLS.tauCeti, label: "Tau Ceti", external: true },
     ],
   },
 ];
 
+/* ------------------------------------------------------------------ */
+/*  Shared icons                                                       */
+/* ------------------------------------------------------------------ */
+
+function ExternalIcon({ className = "w-2.5 h-2.5 opacity-40" }: { className?: string }) {
+  return (
+    <svg className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+    </svg>
+  );
+}
+
+function ChevronIcon({ open }: { open: boolean }) {
+  return (
+    <svg
+      className={`w-2.5 h-2.5 opacity-40 transition-transform duration-150 ${open ? "rotate-180" : ""}`}
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      strokeWidth={2}
+    >
+      <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+    </svg>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                            */
+/* ------------------------------------------------------------------ */
+
+function isGroupActive(group: NavGroup, pathname: string): boolean {
+  if (group.href) return pathname === group.href;
+  return group.links?.some((l) => !l.external && pathname === l.href) ?? false;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Desktop dropdown                                                   */
+/* ------------------------------------------------------------------ */
+
+function DesktopDropdown({
+  group,
+  pathname,
+  openGroup,
+  setOpenGroup,
+}: {
+  group: NavGroup;
+  pathname: string;
+  openGroup: string | null;
+  setOpenGroup: (g: string | null) => void;
+}) {
+  const isOpen = openGroup === group.label;
+  const active = isGroupActive(group, pathname);
+  const closeTimer = useRef<ReturnType<typeof setTimeout>>(null);
+
+  const open = useCallback(() => {
+    if (closeTimer.current) clearTimeout(closeTimer.current);
+    setOpenGroup(group.label);
+  }, [group.label, setOpenGroup]);
+
+  const scheduleClose = useCallback(() => {
+    closeTimer.current = setTimeout(() => setOpenGroup(null), 150);
+  }, [setOpenGroup]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Escape") {
+        setOpenGroup(null);
+        (e.currentTarget as HTMLElement).focus();
+      }
+      if (e.key === "ArrowDown" && !isOpen) {
+        e.preventDefault();
+        open();
+      }
+    },
+    [isOpen, open, setOpenGroup],
+  );
+
+  const tabClasses = `font-[var(--font-display)] text-[0.65rem] tracking-[3px] uppercase no-underline px-3 py-2.5 border border-transparent border-b-0 transition-all flex items-center gap-1.5 relative top-[2px] cursor-pointer select-none ${
+    active
+      ? "text-accent bg-panel border-border border-b-2 border-b-panel glow-accent"
+      : "text-dim hover:text-foreground hover:bg-accent/5 hover:border-border"
+  }`;
+
+  return (
+    <div
+      className="relative"
+      onMouseEnter={open}
+      onMouseLeave={scheduleClose}
+      onKeyDown={handleKeyDown}
+    >
+      <button
+        className={tabClasses}
+        aria-haspopup="true"
+        aria-expanded={isOpen}
+        onClick={() => (isOpen ? setOpenGroup(null) : open())}
+      >
+        {group.label}
+        <ChevronIcon open={isOpen} />
+      </button>
+
+      {isOpen && group.links && (
+        <div
+          className="absolute top-full left-0 mt-[2px] min-w-[180px] bg-panel border border-border shadow-lg z-50"
+          role="menu"
+        >
+          {group.links.map((link) => {
+            const linkActive = !link.external && pathname === link.href;
+            const cls = `block w-full text-left px-4 py-2.5 font-[var(--font-display)] text-[0.6rem] tracking-[2px] uppercase no-underline transition-colors flex items-center gap-2 ${
+              linkActive
+                ? "text-accent bg-accent/10"
+                : "text-dim hover:text-foreground hover:bg-accent/5"
+            }`;
+
+            if (link.external) {
+              return (
+                <a
+                  key={link.href}
+                  href={link.href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className={cls}
+                  role="menuitem"
+                  onClick={() => setOpenGroup(null)}
+                >
+                  {link.label}
+                  <ExternalIcon />
+                </a>
+              );
+            }
+
+            return (
+              <Link
+                key={link.href}
+                href={link.href}
+                className={cls}
+                role="menuitem"
+                onClick={() => setOpenGroup(null)}
+              >
+                {link.label}
+              </Link>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Navigation                                                         */
+/* ------------------------------------------------------------------ */
+
 export function Navigation() {
   const pathname = usePathname();
   const [mobileOpen, setMobileOpen] = useState(false);
+  const [openGroup, setOpenGroup] = useState<string | null>(null);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        setOpenGroup(null);
+        setMobileOpen(false);
+      }
+    };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, []);
+
+  useEffect(() => {
+    if (!openGroup) return;
+    const handler = (e: MouseEvent) => {
+      const nav = document.getElementById("desktop-nav");
+      if (nav && !nav.contains(e.target as Node)) setOpenGroup(null);
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [openGroup]);
 
   return (
     <>
       {/* Header */}
-      <header className="border-b border-border px-4 sm:px-8 py-5 flex justify-between items-center bg-gradient-to-r from-accent/5 to-transparent flex-wrap gap-2.5" role="banner">
+      <header
+        className="border-b border-border px-4 sm:px-8 py-5 flex justify-between items-center bg-gradient-to-r from-accent/5 to-transparent flex-wrap gap-2.5"
+        role="banner"
+      >
         <div className="flex items-center gap-4">
           <Link href="/" className="no-underline">
             <div className="font-[var(--font-display)] text-lg sm:text-xl font-black text-accent glow-accent tracking-[4px]">
@@ -82,67 +266,44 @@ export function Navigation() {
       </header>
 
       {/* Desktop nav */}
-      <nav aria-label="Main navigation" className="bg-background border-b-2 border-border px-4 sm:px-8 pt-2.5 hidden md:flex items-end gap-0 overflow-x-auto scrollbar-none">
-        {/* Home tab */}
-        <Link
-          href="/"
-          className={`font-[var(--font-display)] text-[0.65rem] tracking-[3px] uppercase no-underline px-3 py-2.5 border border-transparent border-b-0 transition-all flex items-center gap-1.5 relative top-[2px] mr-2 ${pathname === "/"
-            ? "text-accent bg-panel border-border border-b-2 border-b-panel glow-accent"
-            : "text-dim hover:text-foreground hover:bg-accent/5 hover:border-border"
-            }`}
-        >
-          <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-            <path strokeLinecap="round" strokeLinejoin="round" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-4 0a1 1 0 01-1-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 01-1 1h-2z" />
-          </svg>
-          HOME
-        </Link>
+      <nav
+        id="desktop-nav"
+        aria-label="Main navigation"
+        className="bg-background border-b-2 border-border px-4 sm:px-8 pt-2.5 hidden md:flex items-end gap-1"
+      >
+        {NAV_GROUPS.map((group) => {
+          if (group.href) {
+            const active = pathname === group.href;
+            return (
+              <Link
+                key={group.label}
+                href={group.href}
+                className={`font-[var(--font-display)] text-[0.65rem] tracking-[3px] uppercase no-underline px-3 py-2.5 border border-transparent border-b-0 transition-all flex items-center gap-1.5 relative top-[2px] ${
+                  active
+                    ? "text-accent bg-panel border-border border-b-2 border-b-panel glow-accent"
+                    : "text-dim hover:text-foreground hover:bg-accent/5 hover:border-border"
+                }`}
+              >
+                {group.icon && (
+                  <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d={group.icon} />
+                  </svg>
+                )}
+                {group.label}
+              </Link>
+            );
+          }
 
-        {NAV_SECTIONS.map((section) => (
-          <div key={section.label} className="flex items-end">
-            {/* Section divider */}
-            <div className="h-5 w-px bg-border mx-1.5 mb-2.5" />
-            {/* Section label */}
-            <div className="font-[var(--font-display)] text-[0.6rem] tracking-[2px] text-dim px-1.5 pb-3 select-none">
-              {section.label}
-            </div>
-            {/* Section links */}
-            {section.links.map((link) => {
-              const isActive = !link.external && pathname === link.href;
-              const baseClasses =
-                "font-[var(--font-display)] text-[0.6rem] tracking-[2px] uppercase text-dim no-underline px-2.5 py-2.5 border border-transparent border-b-0 transition-all flex items-center gap-1.5 relative top-[2px]";
-              const activeClasses = isActive
-                ? "text-accent bg-panel border-border border-b-2 border-b-panel glow-accent"
-                : "hover:text-foreground hover:bg-accent/5 hover:border-border";
-
-              if (link.external) {
-                return (
-                  <a
-                    key={link.href}
-                    href={link.href}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className={`${baseClasses} ${activeClasses}`}
-                  >
-                    {link.label}
-                    <svg className="w-2.5 h-2.5 opacity-40" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                      <path strokeLinecap="round" strokeLinejoin="round" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
-                    </svg>
-                  </a>
-                );
-              }
-
-              return (
-                <Link
-                  key={link.href}
-                  href={link.href}
-                  className={`${baseClasses} ${activeClasses}`}
-                >
-                  {link.label}
-                </Link>
-              );
-            })}
-          </div>
-        ))}
+          return (
+            <DesktopDropdown
+              key={group.label}
+              group={group}
+              pathname={pathname}
+              openGroup={openGroup}
+              setOpenGroup={setOpenGroup}
+            />
+          );
+        })}
       </nav>
 
       {/* Mobile hamburger */}
@@ -175,61 +336,72 @@ export function Navigation() {
       {/* Mobile menu */}
       {mobileOpen && (
         <nav id="mobile-nav-menu" aria-label="Mobile navigation" className="md:hidden bg-panel border-b border-border">
-          {/* Home link */}
-          <Link
-            href="/"
-            className={`block px-6 py-3 text-xs tracking-[2px] uppercase border-b border-border/50 ${pathname === "/"
-              ? "text-accent bg-accent/5"
-              : "text-dim hover:text-accent hover:bg-accent/5"
-              }`}
-            onClick={() => setMobileOpen(false)}
-          >
-            ⌂ Home
-          </Link>
-
-          {NAV_SECTIONS.map((section) => (
-            <div key={section.label}>
-              {/* Section header */}
-              <div className="px-6 py-2 text-[0.6rem] tracking-[3px] uppercase text-dim bg-background/50 border-b border-border/30 font-[var(--font-display)]">
-                {section.label}
-              </div>
-              {section.links.map((link) => {
-                const isActive = !link.external && pathname === link.href;
-                if (link.external) {
-                  return (
-                    <a
-                      key={link.href}
-                      href={link.href}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="block px-8 py-3 text-xs tracking-[2px] uppercase text-dim hover:text-accent hover:bg-accent/5 border-b border-border/50"
-                      onClick={() => setMobileOpen(false)}
-                    >
-                      {link.label} ↗
-                    </a>
-                  );
-                }
-                return (
-                  <Link
-                    key={link.href}
-                    href={link.href}
-                    className={`block px-8 py-3 text-xs tracking-[2px] uppercase border-b border-border/50 ${isActive
+          {NAV_GROUPS.map((group) => {
+            if (group.href) {
+              return (
+                <Link
+                  key={group.label}
+                  href={group.href}
+                  className={`block px-6 py-3 text-xs tracking-[2px] uppercase border-b border-border/50 ${
+                    pathname === group.href
                       ? "text-accent bg-accent/5"
                       : "text-dim hover:text-accent hover:bg-accent/5"
+                  }`}
+                  onClick={() => setMobileOpen(false)}
+                >
+                  ⌂ {group.label}
+                </Link>
+              );
+            }
+
+            return (
+              <div key={group.label}>
+                <div className="px-6 py-2 text-[0.6rem] tracking-[3px] uppercase text-dim bg-background/50 border-b border-border/30 font-[var(--font-display)]">
+                  {group.label}
+                </div>
+                {group.links?.map((link) => {
+                  const linkActive = !link.external && pathname === link.href;
+                  if (link.external) {
+                    return (
+                      <a
+                        key={link.href}
+                        href={link.href}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="block px-8 py-3 text-xs tracking-[2px] uppercase text-dim hover:text-accent hover:bg-accent/5 border-b border-border/50"
+                        onClick={() => setMobileOpen(false)}
+                      >
+                        {link.label} ↗
+                      </a>
+                    );
+                  }
+                  return (
+                    <Link
+                      key={link.href}
+                      href={link.href}
+                      className={`block px-8 py-3 text-xs tracking-[2px] uppercase border-b border-border/50 ${
+                        linkActive
+                          ? "text-accent bg-accent/5"
+                          : "text-dim hover:text-accent hover:bg-accent/5"
                       }`}
-                    onClick={() => setMobileOpen(false)}
-                  >
-                    {link.label}
-                  </Link>
-                );
-              })}
-            </div>
-          ))}
+                      onClick={() => setMobileOpen(false)}
+                    >
+                      {link.label}
+                    </Link>
+                  );
+                })}
+              </div>
+            );
+          })}
         </nav>
       )}
     </>
   );
 }
+
+/* ------------------------------------------------------------------ */
+/*  Header widgets                                                     */
+/* ------------------------------------------------------------------ */
 
 function StatusDot() {
   return (
@@ -268,8 +440,8 @@ function ClientClock() {
           second: "2-digit",
           hour12: true,
         }) +
-        " " +
-        tz
+          " " +
+          tz,
       );
       setUtc(
         now.toLocaleString("en-US", {
@@ -278,7 +450,7 @@ function ClientClock() {
           minute: "2-digit",
           second: "2-digit",
           hour12: true,
-        }) + " UTC"
+        }) + " UTC",
       );
     };
     tick();


### PR DESCRIPTION
## Summary\n\nTwo tightly coupled UX improvements: nav bar redesign and page card deduplication.\n\n### Navigation Redesign (closes #101)\n\n**Before:** 18 items across a single horizontal row, overflowing on screens &lt;1400px.\n\n**After:** 5 grouped dropdown tabs — Home, Community, Marathon, Cryoarchive, Resources.\n\n- Hover-to-open on desktop, click fallback\n- Close on outside click, Escape key\n- Active page highlights its parent tab with accent glow\n- Keyboard accessible (ArrowDown opens, Escape closes)\n- Mobile hamburger menu unchanged (already well-grouped)\n- No horizontal overflow on screens ≥768px\n- Zero extra dependencies — pure React state + Tailwind\n\n### Page Card Dedup (closes #102)\n\n**About page:**\n- Removed GET STARTED cards (4 items — all link to Discord, Dashboard, Community Doc, Community page)\n- Removed WAYS TO CONTRIBUTE grid (6 items — exact duplicate of Contribute page)\n- Removed CREDITS section (3 links — already in Homepage footer)\n- Removed bottom quick-link buttons\n- Kept: prose-only content (What Is This?, Community Structure)\n- Added: two clear CTAs (Get Involved → Contribute, Community Resources → Community)\n\n**Contribute page:**\n- Replaced FOR DEVELOPERS section (tech stack grid + 3 buttons: View Source, Open Issues, API Docs) with a single-line developer note linking to Community Resources\n- Kept: all 6 contribution path cards (contextual CTAs within each path are defensible)\n\n**Impact:** 12 duplicate link instances removed across 2 pages. Zero discoverability loss.\n\n## Testing\n- ✅ `npm run lint` — clean\n- ✅ `npm test` — 73/73 pass\n- ✅ `npm run build` — success