### PR TITLE
feat: stale data detection and indicators for marathon page

### DIFF
--- a/src/app/api/state/latest/route.ts
+++ b/src/app/api/state/latest/route.ts
@@ -5,8 +5,12 @@ import { withCache } from "@/lib/cache";
 /**
  * GET /api/state/latest
  *
- * Returns the latest state snapshot from the database.
- * Data is populated by the Python poller every 5 minutes — no live fallback.
+ * Returns the high-water-mark state snapshot from the database.
+ * Uses ORDER BY kill_count DESC instead of captured_at DESC because
+ * the upstream API may return stale/regressed data, causing the most
+ * recent row to have a LOWER kill count than older rows.
+ *
+ * Data is populated by the Python poller every 15 minutes — no live fallback.
  */
 export async function GET() {
     // Try database first
@@ -16,7 +20,7 @@ export async function GET() {
             const result = await db.query(
                 `SELECT captured_at, kill_count, ship_date, next_update, sectors, memory_flags
          FROM state_snapshots
-         ORDER BY captured_at DESC
+         ORDER BY kill_count DESC
          LIMIT 1`
             );
 

--- a/src/app/marathon/MarathonClient.tsx
+++ b/src/app/marathon/MarathonClient.tsx
@@ -4,6 +4,8 @@ import { useState } from "react";
 import dynamic from "next/dynamic";
 import { formatNumber, timeAgo } from "@/lib/format";
 import { URLS } from "@/lib/urls";
+import { computeStalenessFromTimestamp } from "@/lib/staleness";
+import { DataStaleBanner } from "@/components/DataStaleBanner";
 import type { RangeLabel } from "@/lib/chart-utils";
 
 /* ------------------------------------------------------------------ */
@@ -73,6 +75,8 @@ const KillAnalytics = dynamic(
 
 interface Props {
   initialKillCount: number | null;
+  /** ISO timestamp of the initial data (for staleness detection) */
+  initialCapturedAt: string | null;
 }
 
 /* ------------------------------------------------------------------ */
@@ -81,14 +85,18 @@ interface Props {
 
 const STATE_API = "/api/state/latest";
 
-export function MarathonClient({ initialKillCount }: Props) {
+export function MarathonClient({ initialKillCount, initialCapturedAt }: Props) {
   const [killCount, setKillCount] = useState<number | null>(initialKillCount);
+  const [capturedAt, setCapturedAt] = useState<string | null>(initialCapturedAt);
   const [lastFetch, setLastFetch] = useState<Date | null>(
     initialKillCount !== null ? new Date() : null,
   );
 
   // Shared chart time range — syncs kill chart and player chart
   const [chartRange, setChartRange] = useState<RangeLabel>("24H");
+
+  // Staleness detection for kill count data
+  const staleness = computeStalenessFromTimestamp(capturedAt);
 
   // Refresh kill count from API (lightweight — just the latest state)
   const refreshKillCount = async () => {
@@ -99,10 +107,12 @@ export function MarathonClient({ initialKillCount }: Props) {
       if (!res.ok) return;
       const json = await res.json();
       const kc = json?.data?.killCount;
+      const ca = json?.data?.capturedAt;
       if (typeof kc === "number") {
         setKillCount(kc);
         setLastFetch(new Date());
       }
+      if (ca) setCapturedAt(ca);
     } catch {
       // Silently fail — charts have their own data sources
     }
@@ -119,6 +129,14 @@ export function MarathonClient({ initialKillCount }: Props) {
           KILL COUNTS, PLAYER DATA, ANALYTICS, AND PROJECTIONS
         </p>
       </div>
+
+      {/* Stale data warning */}
+      {staleness?.isStale && (
+        <DataStaleBanner
+          staleness={staleness}
+          detail="The upstream cryoarchive API is returning cached data. Values below reflect the last known good snapshot."
+        />
+      )}
 
       {/* Quick links */}
       <div className="flex items-center justify-center gap-4 flex-wrap mb-10">
@@ -162,11 +180,18 @@ export function MarathonClient({ initialKillCount }: Props) {
           </div>
         </div>
         <div className="ml-auto text-right">
-          {lastFetch && (
+          {staleness?.isStale ? (
+            <div className="text-[0.65rem] text-warn">
+              Data from {new Date(staleness.lastUpdated).toLocaleDateString("en-US", {
+                month: "short",
+                day: "numeric",
+              })}
+            </div>
+          ) : lastFetch ? (
             <div className="text-[0.65rem] text-dim">
               Updated {timeAgo(lastFetch)}
             </div>
-          )}
+          ) : null}
           <div className="text-[0.55rem] text-dim mt-1">
             Click to refresh
           </div>

--- a/src/app/marathon/page.tsx
+++ b/src/app/marathon/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { fetchState } from "@/lib/api";
+import { fetchState, fetchHighWaterCapturedAt } from "@/lib/api";
 import { SITE_URL } from "@/lib/urls";
 import { MarathonClient } from "./MarathonClient";
 
@@ -23,9 +23,15 @@ export default async function MarathonPage() {
   // Pass initial kill count for SSR hydration
   const initialKillCount = state?.uescKillCount ?? null;
 
+  // Get the captured_at timestamp of the high-water row for staleness detection
+  const initialCapturedAt = await fetchHighWaterCapturedAt();
+
   return (
     <main className="px-4 sm:px-8 max-w-[1200px] mx-auto py-8 sm:py-16">
-      <MarathonClient initialKillCount={initialKillCount} />
+      <MarathonClient
+        initialKillCount={initialKillCount}
+        initialCapturedAt={initialCapturedAt}
+      />
     </main>
   );
 }

--- a/src/components/DataStaleBanner.tsx
+++ b/src/components/DataStaleBanner.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import type { StalenessInfo } from "@/lib/staleness";
+
+/* ------------------------------------------------------------------ */
+/*  DataStaleBanner                                                    */
+/*                                                                     */
+/*  Prominent warning banner displayed when upstream data collection   */
+/*  has stalled.  Matches the cryo design language with warn color.    */
+/* ------------------------------------------------------------------ */
+
+interface Props {
+  staleness: StalenessInfo;
+  /** Optional extra context, e.g. "Upstream API returned cached data" */
+  detail?: string;
+}
+
+export function DataStaleBanner({ staleness, detail }: Props) {
+  if (!staleness.isStale) return null;
+
+  const lastUpdated = new Date(staleness.lastUpdated);
+  const formattedTime = lastUpdated.toLocaleString("en-US", {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    hour12: true,
+  });
+
+  return (
+    <div className="cryo-panel border-warn/40 bg-warn/5 p-4 mb-8" role="alert">
+      <div className="absolute top-0 left-0 right-0 h-0.5 bg-gradient-to-r from-warn to-transparent" />
+      <div className="flex items-start gap-3">
+        <div className="text-warn text-lg leading-none mt-0.5" aria-hidden>
+          ⚠
+        </div>
+        <div>
+          <div className="font-[var(--font-display)] text-[0.7rem] tracking-[3px] text-warn font-bold mb-1">
+            DATA COLLECTION PAUSED
+          </div>
+          <div className="text-[0.7rem] text-dim leading-relaxed">
+            Kill count data has not updated in{" "}
+            <span className="text-warn font-semibold">{staleness.ageLabel}</span>.
+            Values shown are from{" "}
+            <span className="text-text-body">{formattedTime}</span>.
+            {detail && (
+              <span className="block mt-1 text-dim/80">{detail}</span>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Compact stale indicator for chart headers.
+ * Shows a small "PAUSED" badge inline with the title.
+ */
+export function StaleChip({ staleness }: { staleness: StalenessInfo | null }) {
+  if (!staleness?.isStale) return null;
+
+  return (
+    <span className="inline-flex items-center gap-1 ml-2 px-1.5 py-0.5 text-[0.5rem] font-[var(--font-display)] tracking-[2px] text-warn border border-warn/30 bg-warn/5">
+      PAUSED
+    </span>
+  );
+}

--- a/src/components/KillAnalytics.tsx
+++ b/src/components/KillAnalytics.tsx
@@ -4,6 +4,7 @@ import { useMemo } from "react";
 import { useKillCountData, useSteamPlayers } from "@/hooks";
 import type { KillCountRow, SteamPlayerRow } from "@/hooks";
 import { formatNumber } from "@/lib/format";
+import { computeStaleness } from "@/lib/staleness";
 
 /* ------------------------------------------------------------------ */
 /*  Types                                                              */
@@ -253,6 +254,12 @@ export function KillAnalytics() {
     [stateRows, steamRows],
   );
 
+  /** Detect stale kill data independently of steam data. */
+  const killDataStale = useMemo(
+    () => computeStaleness(stateRows),
+    [stateRows],
+  );
+
   if (loading) {
     return (
       <div className="cryo-panel p-5 h-[120px] flex items-center justify-center">
@@ -388,6 +395,17 @@ export function KillAnalytics() {
           <span className="text-dim ml-1">(kills per min per 1K players)</span>
         </div>
       </div>
+
+      {/* Stale data notice */}
+      {killDataStale?.isStale && (
+        <div className="cryo-panel p-3 border-warn/20 bg-warn/5 text-[0.6rem] text-dim">
+          <span className="text-warn font-[var(--font-display)] tracking-[2px]">
+            ⚠ DATA PAUSED
+          </span>
+          {" — "}
+          Kill rate analytics are based on the last period of active data collection.
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/KillCountChart.tsx
+++ b/src/components/KillCountChart.tsx
@@ -4,6 +4,8 @@ import { useMemo, useState } from "react";
 import { useKillCountData, useChartRange } from "@/hooks";
 import { URLS } from "@/lib/urls";
 import { THEME, CHART_EXTENDED } from "@/lib/constants";
+import { computeStaleness } from "@/lib/staleness";
+import { StaleChip } from "@/components/DataStaleBanner";
 import {
   ResponsiveContainer,
   ComposedChart,
@@ -156,6 +158,12 @@ export function KillCountChart({ range: externalRange, onRangeChange }: Props = 
     [allData],
   );
 
+  /** Detect stale data — latest data point too old. */
+  const staleness = useMemo(
+    () => computeStaleness(deduped),
+    [deduped],
+  );
+
   /* ---- Loading / error states ---- */
 
   if (loading) {
@@ -202,6 +210,7 @@ export function KillCountChart({ range: externalRange, onRangeChange }: Props = 
       <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3 mb-4">
         <div className="font-[var(--font-display)] text-[0.65rem] tracking-[3px] text-dim">
           KILL COUNT OVER TIME
+          <StaleChip staleness={staleness} />
         </div>
         <div className="flex items-center gap-3 flex-wrap">
           {/* KPM toggle */}

--- a/src/components/KillCountEta.tsx
+++ b/src/components/KillCountEta.tsx
@@ -4,6 +4,7 @@ import { useMemo, useState, useEffect } from "react";
 import { useKillCountData } from "@/hooks";
 import type { KillCountRow } from "@/hooks";
 import { formatNumber } from "@/lib/format";
+import { computeStaleness } from "@/lib/staleness";
 
 /* ------------------------------------------------------------------ */
 /*  Constants                                                          */
@@ -190,6 +191,12 @@ export function KillCountEta({
     return () => clearInterval(id);
   }, []);
 
+  // Detect stale data
+  const staleness = useMemo(
+    () => computeStaleness(rows),
+    [rows],
+  );
+
   // Build projection
   const projection = useMemo((): Projection | null => {
     if (rows.length < 10) return null;
@@ -265,6 +272,82 @@ export function KillCountEta({
   }
 
   const { eta, remaining, currentKpm, avgKpm, dataSpanDays } = projection;
+
+  // When data is stale, show paused state instead of ticking countdown
+  if (staleness?.isStale) {
+    // Progress bar (still valid — uses currentKills which is the high-water mark)
+    const progress = Math.min(100, (currentKills / TARGET) * 100);
+
+    return (
+      <div className="cryo-panel p-5 mb-8">
+        <div className="absolute top-0 left-0 right-0 h-0.5 bg-gradient-to-r from-warn to-transparent" />
+
+        {/* Header row */}
+        <div className="flex items-start justify-between gap-4 flex-wrap mb-4">
+          <div>
+            <div className="font-[var(--font-display)] text-[0.65rem] tracking-[3px] text-dim mb-1">
+              ETA TO 500M KILLS
+            </div>
+            <div className="font-[var(--font-display)] text-xl font-bold text-warn/70 tracking-wider">
+              PROJECTION PAUSED
+            </div>
+            <div className="text-[0.6rem] text-dim mt-1">
+              Data collection paused — ETA will resume when fresh data arrives
+            </div>
+          </div>
+          <div className="text-right">
+            <div className="font-[var(--font-display)] text-[0.55rem] tracking-[2px] text-dim mb-1">
+              LAST ESTIMATE
+            </div>
+            <div className="font-[var(--font-display)] text-sm font-bold text-dim tracking-wider">
+              {eta.toLocaleDateString("en-US", {
+                weekday: "short",
+                month: "short",
+                day: "numeric",
+              })}
+            </div>
+          </div>
+        </div>
+
+        {/* Progress bar */}
+        <div className="mb-4">
+          <div className="flex justify-between text-[0.6rem] text-dim mb-1">
+            <span>{formatNumber(currentKills)}</span>
+            <span>{formatNumber(TARGET)}</span>
+          </div>
+          <div className="h-2 bg-border overflow-hidden">
+            <div
+              className="h-full bg-gradient-to-r from-danger to-warn transition-[width] duration-1000"
+              style={{ width: `${progress}%` }}
+            />
+          </div>
+          <div className="text-[0.6rem] text-dim mt-1">
+            {progress.toFixed(1)}% — {formatNumber(remaining)} remaining
+          </div>
+        </div>
+
+        {/* Stats row */}
+        <div className="flex gap-6 flex-wrap text-[0.6rem]">
+          <div>
+            <span className="font-[var(--font-display)] tracking-[2px] text-dim">
+              AVG RATE{" "}
+            </span>
+            <span className="text-text-body font-bold">
+              {formatNumber(avgKpm)} KPM
+            </span>
+          </div>
+          <div>
+            <span className="font-[var(--font-display)] tracking-[2px] text-dim">
+              MODEL{" "}
+            </span>
+            <span className="text-text-body">
+              diurnal-weighted ({dataSpanDays.toFixed(1)}d of data)
+            </span>
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   // Live countdown
   const msLeft = Math.max(0, eta.getTime() - now);

--- a/src/components/PlayerCountChart.tsx
+++ b/src/components/PlayerCountChart.tsx
@@ -3,6 +3,8 @@
 import { useMemo } from "react";
 import { useSteamPlayers } from "@/hooks";
 import { THEME } from "@/lib/constants";
+import { computeStaleness } from "@/lib/staleness";
+import { StaleChip } from "@/components/DataStaleBanner";
 import {
   ResponsiveContainer,
   AreaChart,
@@ -75,6 +77,12 @@ export function PlayerCountChart({ range, onRangeChange }: Props) {
     [allData],
   );
 
+  /** Detect stale data — Steam player data might still be fresh. */
+  const staleness = useMemo(
+    () => computeStaleness(rows),
+    [rows],
+  );
+
   /** Compute peak and trough for annotation */
   const stats = useMemo(() => {
     if (chartData.length === 0) return null;
@@ -122,6 +130,7 @@ export function PlayerCountChart({ range, onRangeChange }: Props) {
         <div className="flex items-center gap-4">
           <div className="font-[var(--font-display)] text-[0.65rem] tracking-[3px] text-dim">
             STEAM PLAYERS OVER TIME
+            <StaleChip staleness={staleness} />
           </div>
           {stats && (
             <div className="flex gap-4 text-[0.55rem]">

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -25,11 +25,33 @@ export async function fetchState(): Promise<CryoarchiveState | null> {
   const pool = getPool();
   if (!pool) return null;
   try {
+    // Use high-water mark (highest kill_count) instead of latest captured_at.
+    // Upstream API may return stale/regressed data, so the most recent row
+    // can have a LOWER kill_count than older rows.
     const result = await pool.query(
-      "SELECT raw_response FROM state_snapshots ORDER BY captured_at DESC LIMIT 1",
+      "SELECT raw_response FROM state_snapshots ORDER BY kill_count DESC LIMIT 1",
     );
     if (!result.rows.length) return null;
     return result.rows[0].raw_response?.state ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Get the `captured_at` timestamp of the high-water-mark row
+ * (highest kill_count).  Used for staleness detection on the
+ * marathon page — if this timestamp is >1h old, data is stale.
+ */
+export async function fetchHighWaterCapturedAt(): Promise<string | null> {
+  const pool = getPool();
+  if (!pool) return null;
+  try {
+    const result = await pool.query(
+      "SELECT captured_at FROM state_snapshots ORDER BY kill_count DESC LIMIT 1",
+    );
+    if (!result.rows.length) return null;
+    return result.rows[0].captured_at?.toISOString?.() ?? String(result.rows[0].captured_at);
   } catch {
     return null;
   }

--- a/src/lib/staleness.ts
+++ b/src/lib/staleness.ts
@@ -1,0 +1,82 @@
+// ============================================================
+// Staleness detection — determines when upstream data has gone
+// stale so we can show appropriate UI indicators.
+//
+// The upstream cryoarchive API occasionally returns cached/frozen
+// responses.  When the poller keeps writing the same stale data,
+// the monotonic filter in useKillCountData hides the regressed
+// rows, but the latest valid data point gets increasingly old.
+//
+// Threshold: Data older than 1 hour is considered stale (the
+// poller runs every 15 min; 4 missed cycles = something is wrong).
+// ============================================================
+
+/** How old the newest data point can be before we flag it. */
+const STALE_THRESHOLD_MS = 60 * 60 * 1000; // 1 hour
+
+export interface StalenessInfo {
+  /** True when the latest data is older than the threshold. */
+  isStale: boolean;
+  /** The age of the latest data point in milliseconds. */
+  ageMs: number;
+  /** Human-readable age string: "2h 15m", "45m", etc. */
+  ageLabel: string;
+  /** ISO timestamp of the latest data point. */
+  lastUpdated: string;
+}
+
+/**
+ * Compute staleness from a list of data rows that have a `captured_at`
+ * timestamp.  Expects rows sorted ascending (oldest → newest).
+ */
+export function computeStaleness(
+  rows: { captured_at: string }[],
+): StalenessInfo | null {
+  if (rows.length === 0) return null;
+
+  const latest = rows[rows.length - 1];
+  const latestTs = new Date(latest.captured_at).getTime();
+  const ageMs = Date.now() - latestTs;
+
+  return {
+    isStale: ageMs > STALE_THRESHOLD_MS,
+    ageMs,
+    ageLabel: formatAge(ageMs),
+    lastUpdated: latest.captured_at,
+  };
+}
+
+/**
+ * Compute staleness from a single ISO timestamp.
+ */
+export function computeStalenessFromTimestamp(
+  isoTimestamp: string | null,
+): StalenessInfo | null {
+  if (!isoTimestamp) return null;
+
+  const latestTs = new Date(isoTimestamp).getTime();
+  if (isNaN(latestTs)) return null;
+
+  const ageMs = Date.now() - latestTs;
+
+  return {
+    isStale: ageMs > STALE_THRESHOLD_MS,
+    ageMs,
+    ageLabel: formatAge(ageMs),
+    lastUpdated: isoTimestamp,
+  };
+}
+
+/** Format milliseconds as "2d 5h", "3h 12m", "45m", etc. */
+function formatAge(ms: number): string {
+  const totalMins = Math.floor(ms / 60_000);
+  if (totalMins < 60) return `${totalMins}m`;
+
+  const hrs = Math.floor(totalMins / 60);
+  const mins = totalMins % 60;
+  if (hrs < 24) return mins > 0 ? `${hrs}h ${mins}m` : `${hrs}h`;
+
+  const days = Math.floor(hrs / 24);
+  const remHrs = hrs % 24;
+  return remHrs > 0 ? `${days}d ${remHrs}h` : `${days}d`;
+}


### PR DESCRIPTION
## Summary

When the upstream cryoarchive API returns cached/frozen data (as is happening now — kill count stuck at 334M while high-water mark is 349.9M), the marathon page now gracefully handles this:

### Changes

**API fixes:**
- `/api/state/latest` and `fetchState()` now return the high-water-mark row (`ORDER BY kill_count DESC`) instead of the raw latest, which may have regressed kill count values

**Staleness detection:**
- New `src/lib/staleness.ts` utility detects when newest data point is >1h old
- Computes from both row arrays and individual timestamps

**UI indicators:**
- `DataStaleBanner` — prominent warn-colored banner at top of marathon page
- `StaleChip` — compact PAUSED badge for chart headers
- Hero stat shows data date instead of "Updated Xs ago" when stale
- KillCountEta shows "PROJECTION PAUSED" with last estimate instead of ticking countdown
- KillAnalytics shows paused notice footer
- Both charts show PAUSED chip in header (independently — Steam data may still be fresh)

### Testing

- `npx tsc --noEmit` — zero errors
- `npx next build` — clean build

Closes #107